### PR TITLE
cache ci target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,57 @@
+defaults: &defaults
+  docker:
+    - image: cryptape/cita-build:latest
+  working_directory: ~/cita-build
+
 version: 2
 jobs:
-  build:
-    docker:
-      - image: cryptape/cita-build:latest
-    working_directory: ~/cita-build
+  format:
+    <<: *defaults
     steps:
       - checkout
       - run:
           name: format
           command: 'cargo fmt --all -- --write-mode diff'
+  build:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: 'cargo generate-lockfile'      
+      - restore_cache:
+          key: build-cache-{{ checksum "Cargo.lock" }}
       - run:
           name: build
           command: '.circleci/loop_crates_to_run build'
+      - save_cache:
+          key: build-cache-{{ checksum "Cargo.lock" }}
+          paths:
+            - "~/.cargo"
+            - "./target"
+  test:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: 'cargo generate-lockfile' 
+      - restore_cache:
+          key: test-cache-{{ checksum "Cargo.lock" }}
       - run:
           name: test
           command: '.circleci/loop_crates_to_run test'
+      - save_cache:
+          key: test-cache-{{ checksum "Cargo.lock" }}
+          paths:
+            - "~/.cargo"
+            - "./target"
+
+workflows:
+  version: 2
+
+  btd:
+    jobs:
+      - format
+      - build:
+          requires:
+            - format
+      - test:
+          requires:
+            - format

--- a/.circleci/loop_crates_to_run
+++ b/.circleci/loop_crates_to_run
@@ -52,7 +52,7 @@ function cargo_run_all () {
     cargo_run pubsub_kafka
 
     for features in ${FEATURES_FOR_PUBSUB}; do
-        cargo_run pubsub --features ${features}
+        cargo_run pubsub --features "${features}"
     done
 
     cargo_run sha3
@@ -61,13 +61,13 @@ function cargo_run_all () {
 
     for crate in util authority_manage cita-secp256k1 cita-ed25519 cita-sm2; do
         for features in ${FEATURES_FOR_HASH}; do
-            cargo_run ${crate} --features ${features}
+            cargo_run ${crate} --features "${features}"
         done
     done
 
     for crate in cita-crypto libproto proof tx_pool engine_json; do
         for features in "${FEATURES_FOR_HASH_AND_CRYPT[@]}"; do
-            cargo_run ${crate} --features ${features}
+            cargo_run ${crate} --features "${features}"
         done
     done
 

--- a/tx_pool/src/pool.rs
+++ b/tx_pool/src/pool.rs
@@ -265,8 +265,9 @@ impl Pool {
     }
 }
 
-//FIXME
+// TODO: FIXME
 #[cfg(test)]
+#[cfg(feature = "secp256k1")]
 mod tests {
     use super::*;
     use crypto::{CreateKey, KeyPair, PrivKey};


### PR DESCRIPTION
1. Cache target and `.cargo`. Reduce time from 18 mins to 7 mins
2. Add workflow 
3. Fix loop_crates_to_run

Add cache `.cargo`, but still download crates from remotes. Is this the problem of docker?
Maybe adding `$HOME/.cargo/bin/cargo install --path .` in dockerfile can fix this.

Should add quotes for `--features`

```
zhang yaning, [01.01.18 10:26]
➜  tx_pool git:(cache_ci_target) ✗ cargo test —lib —features sm2 sm3hash
    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running /home/u2/cryptape/cita-common/target/debug/deps/tx_pool-7e55adf5ec5c4759

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out

➜  tx_pool git:(cache_ci_target) ✗ cargo test —lib —features 'sm2 sm3hash'
    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running /home/u2/cryptape/cita-common/target/debug/deps/tx_pool-682a871baf61c3f5

running 1 test
test pool::tests::basic ... FAILED

failures:

—— pool::tests::basic stdout ——
  thread 'pool::tests::basic' panicked at 'assertion failed: (left == right)
  left: true,
 right: false', src/pool.rs:302:8
note: Run with RUST_BACKTRACE=1 for a backtrace.


failures:
    pool::tests::basic

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out

error: test failed, to rerun pass '--lib'
```