### PR TITLE
Message refactor flatten message

### DIFF
--- a/LICENSE_HEADER
+++ b/LICENSE_HEADER
@@ -1,0 +1,17 @@
+// CITA
+// Copyright 2016-2018 Cryptape Technologies LLC.
+
+// This program is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any
+// later version.
+
+// This program is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied
+// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+

--- a/libproto/src/auth.rs
+++ b/libproto/src/auth.rs
@@ -1,5 +1,5 @@
 // CITA
-// Copyright 2016-2017 Cryptape Technologies LLC.
+// Copyright 2016-2018 Cryptape Technologies LLC.
 
 // This program is free software: you can redistribute it
 // and/or modify it under the terms of the GNU General Public

--- a/libproto/src/blockchain.rs
+++ b/libproto/src/blockchain.rs
@@ -1,5 +1,5 @@
 // CITA
-// Copyright 2016-2017 Cryptape Technologies LLC.
+// Copyright 2016-2018 Cryptape Technologies LLC.
 
 // This program is free software: you can redistribute it
 // and/or modify it under the terms of the GNU General Public

--- a/libproto/src/communication.proto
+++ b/libproto/src/communication.proto
@@ -1,5 +1,12 @@
 syntax = "proto3";
 
+import "request.proto";
+import "response.proto";
+import "sync.proto";
+import "blockchain.proto";
+import "auth.proto";
+import "executer.proto";
+
 enum MsgType {
     REQUEST = 0;
     HEADER = 1;
@@ -32,5 +39,33 @@ message Message {
     MsgType type = 2;
     uint32 origin = 3;
     OperateType operate = 4;
-    bytes content = 5;
+
+    oneof content {
+
+        bytes RawBytes = 5;
+
+        Request Request = 6;
+        Response Response = 7;
+
+        SyncRequest SyncRequest = 8;
+        SyncResponse SyncResponse = 9;
+
+        Status Status = 10;
+        RichStatus RichStatus = 11;
+
+        Block Block = 12;
+        BlockWithProof BlockWithProof = 13;
+        BlockHeader BlockHeader = 14;
+        BlockTxs BlockTxs = 15;
+
+        BlockTxHashes BlockTxHashes = 16;
+        BlockTxHashesReq BlockTxHashesReq = 17;
+
+        VerifyTxReq VerifyTxReq = 18;
+        VerifyTxResp VerifyTxResp = 19;
+        VerifyBlockReq VerifyBlockReq = 20;
+        VerifyBlockResp VerifyBlockResp = 21;
+
+        ExecutedResult ExecutedResult = 22;
+    }
 }

--- a/libproto/src/communication.rs
+++ b/libproto/src/communication.rs
@@ -45,7 +45,8 @@ pub struct Message {
     pub field_type: MsgType,
     pub origin: u32,
     pub operate: OperateType,
-    pub content: ::std::vec::Vec<u8>,
+    // message oneof groups
+    pub content: ::std::option::Option<Message_oneof_content>,
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
     cached_size: ::protobuf::CachedSize,
@@ -53,6 +54,28 @@ pub struct Message {
 
 // see codegen.rs for the explanation why impl Sync explicitly
 unsafe impl ::std::marker::Sync for Message {}
+
+#[derive(Clone,PartialEq)]
+pub enum Message_oneof_content {
+    RawBytes(::std::vec::Vec<u8>),
+    Request(super::request::Request),
+    Response(super::response::Response),
+    SyncRequest(super::sync::SyncRequest),
+    SyncResponse(super::sync::SyncResponse),
+    Status(super::blockchain::Status),
+    RichStatus(super::blockchain::RichStatus),
+    Block(super::blockchain::Block),
+    BlockWithProof(super::blockchain::BlockWithProof),
+    BlockHeader(super::blockchain::BlockHeader),
+    BlockTxs(super::blockchain::BlockTxs),
+    BlockTxHashes(super::auth::BlockTxHashes),
+    BlockTxHashesReq(super::auth::BlockTxHashesReq),
+    VerifyTxReq(super::auth::VerifyTxReq),
+    VerifyTxResp(super::auth::VerifyTxResp),
+    VerifyBlockReq(super::auth::VerifyBlockReq),
+    VerifyBlockResp(super::auth::VerifyBlockResp),
+    ExecutedResult(super::executer::ExecutedResult),
+}
 
 impl Message {
     pub fn new() -> Message {
@@ -161,43 +184,976 @@ impl Message {
         &mut self.operate
     }
 
-    // bytes content = 5;
+    // bytes RawBytes = 5;
 
-    pub fn clear_content(&mut self) {
-        self.content.clear();
+    pub fn clear_RawBytes(&mut self) {
+        self.content = ::std::option::Option::None;
+    }
+
+    pub fn has_RawBytes(&self) -> bool {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::RawBytes(..)) => true,
+            _ => false,
+        }
     }
 
     // Param is passed by value, moved
-    pub fn set_content(&mut self, v: ::std::vec::Vec<u8>) {
-        self.content = v;
+    pub fn set_RawBytes(&mut self, v: ::std::vec::Vec<u8>) {
+        self.content = ::std::option::Option::Some(Message_oneof_content::RawBytes(v))
     }
 
     // Mutable pointer to the field.
-    // If field is not initialized, it is initialized with default value first.
-    pub fn mut_content(&mut self) -> &mut ::std::vec::Vec<u8> {
-        &mut self.content
+    pub fn mut_RawBytes(&mut self) -> &mut ::std::vec::Vec<u8> {
+        if let ::std::option::Option::Some(Message_oneof_content::RawBytes(_)) = self.content {
+        } else {
+            self.content = ::std::option::Option::Some(Message_oneof_content::RawBytes(::std::vec::Vec::new()));
+        }
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::RawBytes(ref mut v)) => v,
+            _ => panic!(),
+        }
     }
 
     // Take field
-    pub fn take_content(&mut self) -> ::std::vec::Vec<u8> {
-        ::std::mem::replace(&mut self.content, ::std::vec::Vec::new())
+    pub fn take_RawBytes(&mut self) -> ::std::vec::Vec<u8> {
+        if self.has_RawBytes() {
+            match self.content.take() {
+                ::std::option::Option::Some(Message_oneof_content::RawBytes(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            ::std::vec::Vec::new()
+        }
     }
 
-    pub fn get_content(&self) -> &[u8] {
-        &self.content
+    pub fn get_RawBytes(&self) -> &[u8] {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::RawBytes(ref v)) => v,
+            _ => &[],
+        }
     }
 
-    fn get_content_for_reflect(&self) -> &::std::vec::Vec<u8> {
-        &self.content
+    // .Request Request = 6;
+
+    pub fn clear_Request(&mut self) {
+        self.content = ::std::option::Option::None;
     }
 
-    fn mut_content_for_reflect(&mut self) -> &mut ::std::vec::Vec<u8> {
-        &mut self.content
+    pub fn has_Request(&self) -> bool {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::Request(..)) => true,
+            _ => false,
+        }
+    }
+
+    // Param is passed by value, moved
+    pub fn set_Request(&mut self, v: super::request::Request) {
+        self.content = ::std::option::Option::Some(Message_oneof_content::Request(v))
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_Request(&mut self) -> &mut super::request::Request {
+        if let ::std::option::Option::Some(Message_oneof_content::Request(_)) = self.content {
+        } else {
+            self.content = ::std::option::Option::Some(Message_oneof_content::Request(super::request::Request::new()));
+        }
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::Request(ref mut v)) => v,
+            _ => panic!(),
+        }
+    }
+
+    // Take field
+    pub fn take_Request(&mut self) -> super::request::Request {
+        if self.has_Request() {
+            match self.content.take() {
+                ::std::option::Option::Some(Message_oneof_content::Request(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            super::request::Request::new()
+        }
+    }
+
+    pub fn get_Request(&self) -> &super::request::Request {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::Request(ref v)) => v,
+            _ => super::request::Request::default_instance(),
+        }
+    }
+
+    // .Response Response = 7;
+
+    pub fn clear_Response(&mut self) {
+        self.content = ::std::option::Option::None;
+    }
+
+    pub fn has_Response(&self) -> bool {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::Response(..)) => true,
+            _ => false,
+        }
+    }
+
+    // Param is passed by value, moved
+    pub fn set_Response(&mut self, v: super::response::Response) {
+        self.content = ::std::option::Option::Some(Message_oneof_content::Response(v))
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_Response(&mut self) -> &mut super::response::Response {
+        if let ::std::option::Option::Some(Message_oneof_content::Response(_)) = self.content {
+        } else {
+            self.content = ::std::option::Option::Some(Message_oneof_content::Response(super::response::Response::new()));
+        }
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::Response(ref mut v)) => v,
+            _ => panic!(),
+        }
+    }
+
+    // Take field
+    pub fn take_Response(&mut self) -> super::response::Response {
+        if self.has_Response() {
+            match self.content.take() {
+                ::std::option::Option::Some(Message_oneof_content::Response(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            super::response::Response::new()
+        }
+    }
+
+    pub fn get_Response(&self) -> &super::response::Response {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::Response(ref v)) => v,
+            _ => super::response::Response::default_instance(),
+        }
+    }
+
+    // .SyncRequest SyncRequest = 8;
+
+    pub fn clear_SyncRequest(&mut self) {
+        self.content = ::std::option::Option::None;
+    }
+
+    pub fn has_SyncRequest(&self) -> bool {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::SyncRequest(..)) => true,
+            _ => false,
+        }
+    }
+
+    // Param is passed by value, moved
+    pub fn set_SyncRequest(&mut self, v: super::sync::SyncRequest) {
+        self.content = ::std::option::Option::Some(Message_oneof_content::SyncRequest(v))
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_SyncRequest(&mut self) -> &mut super::sync::SyncRequest {
+        if let ::std::option::Option::Some(Message_oneof_content::SyncRequest(_)) = self.content {
+        } else {
+            self.content = ::std::option::Option::Some(Message_oneof_content::SyncRequest(super::sync::SyncRequest::new()));
+        }
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::SyncRequest(ref mut v)) => v,
+            _ => panic!(),
+        }
+    }
+
+    // Take field
+    pub fn take_SyncRequest(&mut self) -> super::sync::SyncRequest {
+        if self.has_SyncRequest() {
+            match self.content.take() {
+                ::std::option::Option::Some(Message_oneof_content::SyncRequest(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            super::sync::SyncRequest::new()
+        }
+    }
+
+    pub fn get_SyncRequest(&self) -> &super::sync::SyncRequest {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::SyncRequest(ref v)) => v,
+            _ => super::sync::SyncRequest::default_instance(),
+        }
+    }
+
+    // .SyncResponse SyncResponse = 9;
+
+    pub fn clear_SyncResponse(&mut self) {
+        self.content = ::std::option::Option::None;
+    }
+
+    pub fn has_SyncResponse(&self) -> bool {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::SyncResponse(..)) => true,
+            _ => false,
+        }
+    }
+
+    // Param is passed by value, moved
+    pub fn set_SyncResponse(&mut self, v: super::sync::SyncResponse) {
+        self.content = ::std::option::Option::Some(Message_oneof_content::SyncResponse(v))
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_SyncResponse(&mut self) -> &mut super::sync::SyncResponse {
+        if let ::std::option::Option::Some(Message_oneof_content::SyncResponse(_)) = self.content {
+        } else {
+            self.content = ::std::option::Option::Some(Message_oneof_content::SyncResponse(super::sync::SyncResponse::new()));
+        }
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::SyncResponse(ref mut v)) => v,
+            _ => panic!(),
+        }
+    }
+
+    // Take field
+    pub fn take_SyncResponse(&mut self) -> super::sync::SyncResponse {
+        if self.has_SyncResponse() {
+            match self.content.take() {
+                ::std::option::Option::Some(Message_oneof_content::SyncResponse(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            super::sync::SyncResponse::new()
+        }
+    }
+
+    pub fn get_SyncResponse(&self) -> &super::sync::SyncResponse {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::SyncResponse(ref v)) => v,
+            _ => super::sync::SyncResponse::default_instance(),
+        }
+    }
+
+    // .Status Status = 10;
+
+    pub fn clear_Status(&mut self) {
+        self.content = ::std::option::Option::None;
+    }
+
+    pub fn has_Status(&self) -> bool {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::Status(..)) => true,
+            _ => false,
+        }
+    }
+
+    // Param is passed by value, moved
+    pub fn set_Status(&mut self, v: super::blockchain::Status) {
+        self.content = ::std::option::Option::Some(Message_oneof_content::Status(v))
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_Status(&mut self) -> &mut super::blockchain::Status {
+        if let ::std::option::Option::Some(Message_oneof_content::Status(_)) = self.content {
+        } else {
+            self.content = ::std::option::Option::Some(Message_oneof_content::Status(super::blockchain::Status::new()));
+        }
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::Status(ref mut v)) => v,
+            _ => panic!(),
+        }
+    }
+
+    // Take field
+    pub fn take_Status(&mut self) -> super::blockchain::Status {
+        if self.has_Status() {
+            match self.content.take() {
+                ::std::option::Option::Some(Message_oneof_content::Status(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            super::blockchain::Status::new()
+        }
+    }
+
+    pub fn get_Status(&self) -> &super::blockchain::Status {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::Status(ref v)) => v,
+            _ => super::blockchain::Status::default_instance(),
+        }
+    }
+
+    // .RichStatus RichStatus = 11;
+
+    pub fn clear_RichStatus(&mut self) {
+        self.content = ::std::option::Option::None;
+    }
+
+    pub fn has_RichStatus(&self) -> bool {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::RichStatus(..)) => true,
+            _ => false,
+        }
+    }
+
+    // Param is passed by value, moved
+    pub fn set_RichStatus(&mut self, v: super::blockchain::RichStatus) {
+        self.content = ::std::option::Option::Some(Message_oneof_content::RichStatus(v))
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_RichStatus(&mut self) -> &mut super::blockchain::RichStatus {
+        if let ::std::option::Option::Some(Message_oneof_content::RichStatus(_)) = self.content {
+        } else {
+            self.content = ::std::option::Option::Some(Message_oneof_content::RichStatus(super::blockchain::RichStatus::new()));
+        }
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::RichStatus(ref mut v)) => v,
+            _ => panic!(),
+        }
+    }
+
+    // Take field
+    pub fn take_RichStatus(&mut self) -> super::blockchain::RichStatus {
+        if self.has_RichStatus() {
+            match self.content.take() {
+                ::std::option::Option::Some(Message_oneof_content::RichStatus(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            super::blockchain::RichStatus::new()
+        }
+    }
+
+    pub fn get_RichStatus(&self) -> &super::blockchain::RichStatus {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::RichStatus(ref v)) => v,
+            _ => super::blockchain::RichStatus::default_instance(),
+        }
+    }
+
+    // .Block Block = 12;
+
+    pub fn clear_Block(&mut self) {
+        self.content = ::std::option::Option::None;
+    }
+
+    pub fn has_Block(&self) -> bool {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::Block(..)) => true,
+            _ => false,
+        }
+    }
+
+    // Param is passed by value, moved
+    pub fn set_Block(&mut self, v: super::blockchain::Block) {
+        self.content = ::std::option::Option::Some(Message_oneof_content::Block(v))
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_Block(&mut self) -> &mut super::blockchain::Block {
+        if let ::std::option::Option::Some(Message_oneof_content::Block(_)) = self.content {
+        } else {
+            self.content = ::std::option::Option::Some(Message_oneof_content::Block(super::blockchain::Block::new()));
+        }
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::Block(ref mut v)) => v,
+            _ => panic!(),
+        }
+    }
+
+    // Take field
+    pub fn take_Block(&mut self) -> super::blockchain::Block {
+        if self.has_Block() {
+            match self.content.take() {
+                ::std::option::Option::Some(Message_oneof_content::Block(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            super::blockchain::Block::new()
+        }
+    }
+
+    pub fn get_Block(&self) -> &super::blockchain::Block {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::Block(ref v)) => v,
+            _ => super::blockchain::Block::default_instance(),
+        }
+    }
+
+    // .BlockWithProof BlockWithProof = 13;
+
+    pub fn clear_BlockWithProof(&mut self) {
+        self.content = ::std::option::Option::None;
+    }
+
+    pub fn has_BlockWithProof(&self) -> bool {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::BlockWithProof(..)) => true,
+            _ => false,
+        }
+    }
+
+    // Param is passed by value, moved
+    pub fn set_BlockWithProof(&mut self, v: super::blockchain::BlockWithProof) {
+        self.content = ::std::option::Option::Some(Message_oneof_content::BlockWithProof(v))
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_BlockWithProof(&mut self) -> &mut super::blockchain::BlockWithProof {
+        if let ::std::option::Option::Some(Message_oneof_content::BlockWithProof(_)) = self.content {
+        } else {
+            self.content = ::std::option::Option::Some(Message_oneof_content::BlockWithProof(super::blockchain::BlockWithProof::new()));
+        }
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::BlockWithProof(ref mut v)) => v,
+            _ => panic!(),
+        }
+    }
+
+    // Take field
+    pub fn take_BlockWithProof(&mut self) -> super::blockchain::BlockWithProof {
+        if self.has_BlockWithProof() {
+            match self.content.take() {
+                ::std::option::Option::Some(Message_oneof_content::BlockWithProof(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            super::blockchain::BlockWithProof::new()
+        }
+    }
+
+    pub fn get_BlockWithProof(&self) -> &super::blockchain::BlockWithProof {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::BlockWithProof(ref v)) => v,
+            _ => super::blockchain::BlockWithProof::default_instance(),
+        }
+    }
+
+    // .BlockHeader BlockHeader = 14;
+
+    pub fn clear_BlockHeader(&mut self) {
+        self.content = ::std::option::Option::None;
+    }
+
+    pub fn has_BlockHeader(&self) -> bool {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::BlockHeader(..)) => true,
+            _ => false,
+        }
+    }
+
+    // Param is passed by value, moved
+    pub fn set_BlockHeader(&mut self, v: super::blockchain::BlockHeader) {
+        self.content = ::std::option::Option::Some(Message_oneof_content::BlockHeader(v))
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_BlockHeader(&mut self) -> &mut super::blockchain::BlockHeader {
+        if let ::std::option::Option::Some(Message_oneof_content::BlockHeader(_)) = self.content {
+        } else {
+            self.content = ::std::option::Option::Some(Message_oneof_content::BlockHeader(super::blockchain::BlockHeader::new()));
+        }
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::BlockHeader(ref mut v)) => v,
+            _ => panic!(),
+        }
+    }
+
+    // Take field
+    pub fn take_BlockHeader(&mut self) -> super::blockchain::BlockHeader {
+        if self.has_BlockHeader() {
+            match self.content.take() {
+                ::std::option::Option::Some(Message_oneof_content::BlockHeader(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            super::blockchain::BlockHeader::new()
+        }
+    }
+
+    pub fn get_BlockHeader(&self) -> &super::blockchain::BlockHeader {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::BlockHeader(ref v)) => v,
+            _ => super::blockchain::BlockHeader::default_instance(),
+        }
+    }
+
+    // .BlockTxs BlockTxs = 15;
+
+    pub fn clear_BlockTxs(&mut self) {
+        self.content = ::std::option::Option::None;
+    }
+
+    pub fn has_BlockTxs(&self) -> bool {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::BlockTxs(..)) => true,
+            _ => false,
+        }
+    }
+
+    // Param is passed by value, moved
+    pub fn set_BlockTxs(&mut self, v: super::blockchain::BlockTxs) {
+        self.content = ::std::option::Option::Some(Message_oneof_content::BlockTxs(v))
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_BlockTxs(&mut self) -> &mut super::blockchain::BlockTxs {
+        if let ::std::option::Option::Some(Message_oneof_content::BlockTxs(_)) = self.content {
+        } else {
+            self.content = ::std::option::Option::Some(Message_oneof_content::BlockTxs(super::blockchain::BlockTxs::new()));
+        }
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::BlockTxs(ref mut v)) => v,
+            _ => panic!(),
+        }
+    }
+
+    // Take field
+    pub fn take_BlockTxs(&mut self) -> super::blockchain::BlockTxs {
+        if self.has_BlockTxs() {
+            match self.content.take() {
+                ::std::option::Option::Some(Message_oneof_content::BlockTxs(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            super::blockchain::BlockTxs::new()
+        }
+    }
+
+    pub fn get_BlockTxs(&self) -> &super::blockchain::BlockTxs {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::BlockTxs(ref v)) => v,
+            _ => super::blockchain::BlockTxs::default_instance(),
+        }
+    }
+
+    // .BlockTxHashes BlockTxHashes = 16;
+
+    pub fn clear_BlockTxHashes(&mut self) {
+        self.content = ::std::option::Option::None;
+    }
+
+    pub fn has_BlockTxHashes(&self) -> bool {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::BlockTxHashes(..)) => true,
+            _ => false,
+        }
+    }
+
+    // Param is passed by value, moved
+    pub fn set_BlockTxHashes(&mut self, v: super::auth::BlockTxHashes) {
+        self.content = ::std::option::Option::Some(Message_oneof_content::BlockTxHashes(v))
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_BlockTxHashes(&mut self) -> &mut super::auth::BlockTxHashes {
+        if let ::std::option::Option::Some(Message_oneof_content::BlockTxHashes(_)) = self.content {
+        } else {
+            self.content = ::std::option::Option::Some(Message_oneof_content::BlockTxHashes(super::auth::BlockTxHashes::new()));
+        }
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::BlockTxHashes(ref mut v)) => v,
+            _ => panic!(),
+        }
+    }
+
+    // Take field
+    pub fn take_BlockTxHashes(&mut self) -> super::auth::BlockTxHashes {
+        if self.has_BlockTxHashes() {
+            match self.content.take() {
+                ::std::option::Option::Some(Message_oneof_content::BlockTxHashes(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            super::auth::BlockTxHashes::new()
+        }
+    }
+
+    pub fn get_BlockTxHashes(&self) -> &super::auth::BlockTxHashes {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::BlockTxHashes(ref v)) => v,
+            _ => super::auth::BlockTxHashes::default_instance(),
+        }
+    }
+
+    // .BlockTxHashesReq BlockTxHashesReq = 17;
+
+    pub fn clear_BlockTxHashesReq(&mut self) {
+        self.content = ::std::option::Option::None;
+    }
+
+    pub fn has_BlockTxHashesReq(&self) -> bool {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::BlockTxHashesReq(..)) => true,
+            _ => false,
+        }
+    }
+
+    // Param is passed by value, moved
+    pub fn set_BlockTxHashesReq(&mut self, v: super::auth::BlockTxHashesReq) {
+        self.content = ::std::option::Option::Some(Message_oneof_content::BlockTxHashesReq(v))
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_BlockTxHashesReq(&mut self) -> &mut super::auth::BlockTxHashesReq {
+        if let ::std::option::Option::Some(Message_oneof_content::BlockTxHashesReq(_)) = self.content {
+        } else {
+            self.content = ::std::option::Option::Some(Message_oneof_content::BlockTxHashesReq(super::auth::BlockTxHashesReq::new()));
+        }
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::BlockTxHashesReq(ref mut v)) => v,
+            _ => panic!(),
+        }
+    }
+
+    // Take field
+    pub fn take_BlockTxHashesReq(&mut self) -> super::auth::BlockTxHashesReq {
+        if self.has_BlockTxHashesReq() {
+            match self.content.take() {
+                ::std::option::Option::Some(Message_oneof_content::BlockTxHashesReq(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            super::auth::BlockTxHashesReq::new()
+        }
+    }
+
+    pub fn get_BlockTxHashesReq(&self) -> &super::auth::BlockTxHashesReq {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::BlockTxHashesReq(ref v)) => v,
+            _ => super::auth::BlockTxHashesReq::default_instance(),
+        }
+    }
+
+    // .VerifyTxReq VerifyTxReq = 18;
+
+    pub fn clear_VerifyTxReq(&mut self) {
+        self.content = ::std::option::Option::None;
+    }
+
+    pub fn has_VerifyTxReq(&self) -> bool {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::VerifyTxReq(..)) => true,
+            _ => false,
+        }
+    }
+
+    // Param is passed by value, moved
+    pub fn set_VerifyTxReq(&mut self, v: super::auth::VerifyTxReq) {
+        self.content = ::std::option::Option::Some(Message_oneof_content::VerifyTxReq(v))
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_VerifyTxReq(&mut self) -> &mut super::auth::VerifyTxReq {
+        if let ::std::option::Option::Some(Message_oneof_content::VerifyTxReq(_)) = self.content {
+        } else {
+            self.content = ::std::option::Option::Some(Message_oneof_content::VerifyTxReq(super::auth::VerifyTxReq::new()));
+        }
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::VerifyTxReq(ref mut v)) => v,
+            _ => panic!(),
+        }
+    }
+
+    // Take field
+    pub fn take_VerifyTxReq(&mut self) -> super::auth::VerifyTxReq {
+        if self.has_VerifyTxReq() {
+            match self.content.take() {
+                ::std::option::Option::Some(Message_oneof_content::VerifyTxReq(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            super::auth::VerifyTxReq::new()
+        }
+    }
+
+    pub fn get_VerifyTxReq(&self) -> &super::auth::VerifyTxReq {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::VerifyTxReq(ref v)) => v,
+            _ => super::auth::VerifyTxReq::default_instance(),
+        }
+    }
+
+    // .VerifyTxResp VerifyTxResp = 19;
+
+    pub fn clear_VerifyTxResp(&mut self) {
+        self.content = ::std::option::Option::None;
+    }
+
+    pub fn has_VerifyTxResp(&self) -> bool {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::VerifyTxResp(..)) => true,
+            _ => false,
+        }
+    }
+
+    // Param is passed by value, moved
+    pub fn set_VerifyTxResp(&mut self, v: super::auth::VerifyTxResp) {
+        self.content = ::std::option::Option::Some(Message_oneof_content::VerifyTxResp(v))
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_VerifyTxResp(&mut self) -> &mut super::auth::VerifyTxResp {
+        if let ::std::option::Option::Some(Message_oneof_content::VerifyTxResp(_)) = self.content {
+        } else {
+            self.content = ::std::option::Option::Some(Message_oneof_content::VerifyTxResp(super::auth::VerifyTxResp::new()));
+        }
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::VerifyTxResp(ref mut v)) => v,
+            _ => panic!(),
+        }
+    }
+
+    // Take field
+    pub fn take_VerifyTxResp(&mut self) -> super::auth::VerifyTxResp {
+        if self.has_VerifyTxResp() {
+            match self.content.take() {
+                ::std::option::Option::Some(Message_oneof_content::VerifyTxResp(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            super::auth::VerifyTxResp::new()
+        }
+    }
+
+    pub fn get_VerifyTxResp(&self) -> &super::auth::VerifyTxResp {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::VerifyTxResp(ref v)) => v,
+            _ => super::auth::VerifyTxResp::default_instance(),
+        }
+    }
+
+    // .VerifyBlockReq VerifyBlockReq = 20;
+
+    pub fn clear_VerifyBlockReq(&mut self) {
+        self.content = ::std::option::Option::None;
+    }
+
+    pub fn has_VerifyBlockReq(&self) -> bool {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::VerifyBlockReq(..)) => true,
+            _ => false,
+        }
+    }
+
+    // Param is passed by value, moved
+    pub fn set_VerifyBlockReq(&mut self, v: super::auth::VerifyBlockReq) {
+        self.content = ::std::option::Option::Some(Message_oneof_content::VerifyBlockReq(v))
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_VerifyBlockReq(&mut self) -> &mut super::auth::VerifyBlockReq {
+        if let ::std::option::Option::Some(Message_oneof_content::VerifyBlockReq(_)) = self.content {
+        } else {
+            self.content = ::std::option::Option::Some(Message_oneof_content::VerifyBlockReq(super::auth::VerifyBlockReq::new()));
+        }
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::VerifyBlockReq(ref mut v)) => v,
+            _ => panic!(),
+        }
+    }
+
+    // Take field
+    pub fn take_VerifyBlockReq(&mut self) -> super::auth::VerifyBlockReq {
+        if self.has_VerifyBlockReq() {
+            match self.content.take() {
+                ::std::option::Option::Some(Message_oneof_content::VerifyBlockReq(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            super::auth::VerifyBlockReq::new()
+        }
+    }
+
+    pub fn get_VerifyBlockReq(&self) -> &super::auth::VerifyBlockReq {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::VerifyBlockReq(ref v)) => v,
+            _ => super::auth::VerifyBlockReq::default_instance(),
+        }
+    }
+
+    // .VerifyBlockResp VerifyBlockResp = 21;
+
+    pub fn clear_VerifyBlockResp(&mut self) {
+        self.content = ::std::option::Option::None;
+    }
+
+    pub fn has_VerifyBlockResp(&self) -> bool {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::VerifyBlockResp(..)) => true,
+            _ => false,
+        }
+    }
+
+    // Param is passed by value, moved
+    pub fn set_VerifyBlockResp(&mut self, v: super::auth::VerifyBlockResp) {
+        self.content = ::std::option::Option::Some(Message_oneof_content::VerifyBlockResp(v))
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_VerifyBlockResp(&mut self) -> &mut super::auth::VerifyBlockResp {
+        if let ::std::option::Option::Some(Message_oneof_content::VerifyBlockResp(_)) = self.content {
+        } else {
+            self.content = ::std::option::Option::Some(Message_oneof_content::VerifyBlockResp(super::auth::VerifyBlockResp::new()));
+        }
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::VerifyBlockResp(ref mut v)) => v,
+            _ => panic!(),
+        }
+    }
+
+    // Take field
+    pub fn take_VerifyBlockResp(&mut self) -> super::auth::VerifyBlockResp {
+        if self.has_VerifyBlockResp() {
+            match self.content.take() {
+                ::std::option::Option::Some(Message_oneof_content::VerifyBlockResp(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            super::auth::VerifyBlockResp::new()
+        }
+    }
+
+    pub fn get_VerifyBlockResp(&self) -> &super::auth::VerifyBlockResp {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::VerifyBlockResp(ref v)) => v,
+            _ => super::auth::VerifyBlockResp::default_instance(),
+        }
+    }
+
+    // .ExecutedResult ExecutedResult = 22;
+
+    pub fn clear_ExecutedResult(&mut self) {
+        self.content = ::std::option::Option::None;
+    }
+
+    pub fn has_ExecutedResult(&self) -> bool {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::ExecutedResult(..)) => true,
+            _ => false,
+        }
+    }
+
+    // Param is passed by value, moved
+    pub fn set_ExecutedResult(&mut self, v: super::executer::ExecutedResult) {
+        self.content = ::std::option::Option::Some(Message_oneof_content::ExecutedResult(v))
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_ExecutedResult(&mut self) -> &mut super::executer::ExecutedResult {
+        if let ::std::option::Option::Some(Message_oneof_content::ExecutedResult(_)) = self.content {
+        } else {
+            self.content = ::std::option::Option::Some(Message_oneof_content::ExecutedResult(super::executer::ExecutedResult::new()));
+        }
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::ExecutedResult(ref mut v)) => v,
+            _ => panic!(),
+        }
+    }
+
+    // Take field
+    pub fn take_ExecutedResult(&mut self) -> super::executer::ExecutedResult {
+        if self.has_ExecutedResult() {
+            match self.content.take() {
+                ::std::option::Option::Some(Message_oneof_content::ExecutedResult(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            super::executer::ExecutedResult::new()
+        }
+    }
+
+    pub fn get_ExecutedResult(&self) -> &super::executer::ExecutedResult {
+        match self.content {
+            ::std::option::Option::Some(Message_oneof_content::ExecutedResult(ref v)) => v,
+            _ => super::executer::ExecutedResult::default_instance(),
+        }
     }
 }
 
 impl ::protobuf::Message for Message {
     fn is_initialized(&self) -> bool {
+        if let Some(Message_oneof_content::Request(ref v)) = self.content {
+            if !v.is_initialized() {
+                return false;
+            }
+        }
+        if let Some(Message_oneof_content::Response(ref v)) = self.content {
+            if !v.is_initialized() {
+                return false;
+            }
+        }
+        if let Some(Message_oneof_content::SyncRequest(ref v)) = self.content {
+            if !v.is_initialized() {
+                return false;
+            }
+        }
+        if let Some(Message_oneof_content::SyncResponse(ref v)) = self.content {
+            if !v.is_initialized() {
+                return false;
+            }
+        }
+        if let Some(Message_oneof_content::Status(ref v)) = self.content {
+            if !v.is_initialized() {
+                return false;
+            }
+        }
+        if let Some(Message_oneof_content::RichStatus(ref v)) = self.content {
+            if !v.is_initialized() {
+                return false;
+            }
+        }
+        if let Some(Message_oneof_content::Block(ref v)) = self.content {
+            if !v.is_initialized() {
+                return false;
+            }
+        }
+        if let Some(Message_oneof_content::BlockWithProof(ref v)) = self.content {
+            if !v.is_initialized() {
+                return false;
+            }
+        }
+        if let Some(Message_oneof_content::BlockHeader(ref v)) = self.content {
+            if !v.is_initialized() {
+                return false;
+            }
+        }
+        if let Some(Message_oneof_content::BlockTxs(ref v)) = self.content {
+            if !v.is_initialized() {
+                return false;
+            }
+        }
+        if let Some(Message_oneof_content::BlockTxHashes(ref v)) = self.content {
+            if !v.is_initialized() {
+                return false;
+            }
+        }
+        if let Some(Message_oneof_content::BlockTxHashesReq(ref v)) = self.content {
+            if !v.is_initialized() {
+                return false;
+            }
+        }
+        if let Some(Message_oneof_content::VerifyTxReq(ref v)) = self.content {
+            if !v.is_initialized() {
+                return false;
+            }
+        }
+        if let Some(Message_oneof_content::VerifyTxResp(ref v)) = self.content {
+            if !v.is_initialized() {
+                return false;
+            }
+        }
+        if let Some(Message_oneof_content::VerifyBlockReq(ref v)) = self.content {
+            if !v.is_initialized() {
+                return false;
+            }
+        }
+        if let Some(Message_oneof_content::VerifyBlockResp(ref v)) = self.content {
+            if !v.is_initialized() {
+                return false;
+            }
+        }
+        if let Some(Message_oneof_content::ExecutedResult(ref v)) = self.content {
+            if !v.is_initialized() {
+                return false;
+            }
+        }
         true
     }
 
@@ -234,7 +1190,112 @@ impl ::protobuf::Message for Message {
                     self.operate = tmp;
                 },
                 5 => {
-                    ::protobuf::rt::read_singular_proto3_bytes_into(wire_type, is, &mut self.content)?;
+                    if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    self.content = ::std::option::Option::Some(Message_oneof_content::RawBytes(is.read_bytes()?));
+                },
+                6 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    self.content = ::std::option::Option::Some(Message_oneof_content::Request(is.read_message()?));
+                },
+                7 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    self.content = ::std::option::Option::Some(Message_oneof_content::Response(is.read_message()?));
+                },
+                8 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    self.content = ::std::option::Option::Some(Message_oneof_content::SyncRequest(is.read_message()?));
+                },
+                9 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    self.content = ::std::option::Option::Some(Message_oneof_content::SyncResponse(is.read_message()?));
+                },
+                10 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    self.content = ::std::option::Option::Some(Message_oneof_content::Status(is.read_message()?));
+                },
+                11 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    self.content = ::std::option::Option::Some(Message_oneof_content::RichStatus(is.read_message()?));
+                },
+                12 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    self.content = ::std::option::Option::Some(Message_oneof_content::Block(is.read_message()?));
+                },
+                13 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    self.content = ::std::option::Option::Some(Message_oneof_content::BlockWithProof(is.read_message()?));
+                },
+                14 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    self.content = ::std::option::Option::Some(Message_oneof_content::BlockHeader(is.read_message()?));
+                },
+                15 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    self.content = ::std::option::Option::Some(Message_oneof_content::BlockTxs(is.read_message()?));
+                },
+                16 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    self.content = ::std::option::Option::Some(Message_oneof_content::BlockTxHashes(is.read_message()?));
+                },
+                17 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    self.content = ::std::option::Option::Some(Message_oneof_content::BlockTxHashesReq(is.read_message()?));
+                },
+                18 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    self.content = ::std::option::Option::Some(Message_oneof_content::VerifyTxReq(is.read_message()?));
+                },
+                19 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    self.content = ::std::option::Option::Some(Message_oneof_content::VerifyTxResp(is.read_message()?));
+                },
+                20 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    self.content = ::std::option::Option::Some(Message_oneof_content::VerifyBlockReq(is.read_message()?));
+                },
+                21 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    self.content = ::std::option::Option::Some(Message_oneof_content::VerifyBlockResp(is.read_message()?));
+                },
+                22 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeLengthDelimited {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    self.content = ::std::option::Option::Some(Message_oneof_content::ExecutedResult(is.read_message()?));
                 },
                 _ => {
                     ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
@@ -260,8 +1321,80 @@ impl ::protobuf::Message for Message {
         if self.operate != OperateType::BROADCAST {
             my_size += ::protobuf::rt::enum_size(4, self.operate);
         }
-        if !self.content.is_empty() {
-            my_size += ::protobuf::rt::bytes_size(5, &self.content);
+        if let ::std::option::Option::Some(ref v) = self.content {
+            match v {
+                &Message_oneof_content::RawBytes(ref v) => {
+                    my_size += ::protobuf::rt::bytes_size(5, &v);
+                },
+                &Message_oneof_content::Request(ref v) => {
+                    let len = v.compute_size();
+                    my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+                },
+                &Message_oneof_content::Response(ref v) => {
+                    let len = v.compute_size();
+                    my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+                },
+                &Message_oneof_content::SyncRequest(ref v) => {
+                    let len = v.compute_size();
+                    my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+                },
+                &Message_oneof_content::SyncResponse(ref v) => {
+                    let len = v.compute_size();
+                    my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+                },
+                &Message_oneof_content::Status(ref v) => {
+                    let len = v.compute_size();
+                    my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+                },
+                &Message_oneof_content::RichStatus(ref v) => {
+                    let len = v.compute_size();
+                    my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+                },
+                &Message_oneof_content::Block(ref v) => {
+                    let len = v.compute_size();
+                    my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+                },
+                &Message_oneof_content::BlockWithProof(ref v) => {
+                    let len = v.compute_size();
+                    my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+                },
+                &Message_oneof_content::BlockHeader(ref v) => {
+                    let len = v.compute_size();
+                    my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+                },
+                &Message_oneof_content::BlockTxs(ref v) => {
+                    let len = v.compute_size();
+                    my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+                },
+                &Message_oneof_content::BlockTxHashes(ref v) => {
+                    let len = v.compute_size();
+                    my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+                },
+                &Message_oneof_content::BlockTxHashesReq(ref v) => {
+                    let len = v.compute_size();
+                    my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+                },
+                &Message_oneof_content::VerifyTxReq(ref v) => {
+                    let len = v.compute_size();
+                    my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+                },
+                &Message_oneof_content::VerifyTxResp(ref v) => {
+                    let len = v.compute_size();
+                    my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+                },
+                &Message_oneof_content::VerifyBlockReq(ref v) => {
+                    let len = v.compute_size();
+                    my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+                },
+                &Message_oneof_content::VerifyBlockResp(ref v) => {
+                    let len = v.compute_size();
+                    my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+                },
+                &Message_oneof_content::ExecutedResult(ref v) => {
+                    let len = v.compute_size();
+                    my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+                },
+            };
         }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
@@ -281,8 +1414,97 @@ impl ::protobuf::Message for Message {
         if self.operate != OperateType::BROADCAST {
             os.write_enum(4, self.operate.value())?;
         }
-        if !self.content.is_empty() {
-            os.write_bytes(5, &self.content)?;
+        if let ::std::option::Option::Some(ref v) = self.content {
+            match v {
+                &Message_oneof_content::RawBytes(ref v) => {
+                    os.write_bytes(5, v)?;
+                },
+                &Message_oneof_content::Request(ref v) => {
+                    os.write_tag(6, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+                    os.write_raw_varint32(v.get_cached_size())?;
+                    v.write_to_with_cached_sizes(os)?;
+                },
+                &Message_oneof_content::Response(ref v) => {
+                    os.write_tag(7, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+                    os.write_raw_varint32(v.get_cached_size())?;
+                    v.write_to_with_cached_sizes(os)?;
+                },
+                &Message_oneof_content::SyncRequest(ref v) => {
+                    os.write_tag(8, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+                    os.write_raw_varint32(v.get_cached_size())?;
+                    v.write_to_with_cached_sizes(os)?;
+                },
+                &Message_oneof_content::SyncResponse(ref v) => {
+                    os.write_tag(9, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+                    os.write_raw_varint32(v.get_cached_size())?;
+                    v.write_to_with_cached_sizes(os)?;
+                },
+                &Message_oneof_content::Status(ref v) => {
+                    os.write_tag(10, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+                    os.write_raw_varint32(v.get_cached_size())?;
+                    v.write_to_with_cached_sizes(os)?;
+                },
+                &Message_oneof_content::RichStatus(ref v) => {
+                    os.write_tag(11, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+                    os.write_raw_varint32(v.get_cached_size())?;
+                    v.write_to_with_cached_sizes(os)?;
+                },
+                &Message_oneof_content::Block(ref v) => {
+                    os.write_tag(12, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+                    os.write_raw_varint32(v.get_cached_size())?;
+                    v.write_to_with_cached_sizes(os)?;
+                },
+                &Message_oneof_content::BlockWithProof(ref v) => {
+                    os.write_tag(13, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+                    os.write_raw_varint32(v.get_cached_size())?;
+                    v.write_to_with_cached_sizes(os)?;
+                },
+                &Message_oneof_content::BlockHeader(ref v) => {
+                    os.write_tag(14, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+                    os.write_raw_varint32(v.get_cached_size())?;
+                    v.write_to_with_cached_sizes(os)?;
+                },
+                &Message_oneof_content::BlockTxs(ref v) => {
+                    os.write_tag(15, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+                    os.write_raw_varint32(v.get_cached_size())?;
+                    v.write_to_with_cached_sizes(os)?;
+                },
+                &Message_oneof_content::BlockTxHashes(ref v) => {
+                    os.write_tag(16, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+                    os.write_raw_varint32(v.get_cached_size())?;
+                    v.write_to_with_cached_sizes(os)?;
+                },
+                &Message_oneof_content::BlockTxHashesReq(ref v) => {
+                    os.write_tag(17, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+                    os.write_raw_varint32(v.get_cached_size())?;
+                    v.write_to_with_cached_sizes(os)?;
+                },
+                &Message_oneof_content::VerifyTxReq(ref v) => {
+                    os.write_tag(18, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+                    os.write_raw_varint32(v.get_cached_size())?;
+                    v.write_to_with_cached_sizes(os)?;
+                },
+                &Message_oneof_content::VerifyTxResp(ref v) => {
+                    os.write_tag(19, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+                    os.write_raw_varint32(v.get_cached_size())?;
+                    v.write_to_with_cached_sizes(os)?;
+                },
+                &Message_oneof_content::VerifyBlockReq(ref v) => {
+                    os.write_tag(20, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+                    os.write_raw_varint32(v.get_cached_size())?;
+                    v.write_to_with_cached_sizes(os)?;
+                },
+                &Message_oneof_content::VerifyBlockResp(ref v) => {
+                    os.write_tag(21, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+                    os.write_raw_varint32(v.get_cached_size())?;
+                    v.write_to_with_cached_sizes(os)?;
+                },
+                &Message_oneof_content::ExecutedResult(ref v) => {
+                    os.write_tag(22, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+                    os.write_raw_varint32(v.get_cached_size())?;
+                    v.write_to_with_cached_sizes(os)?;
+                },
+            };
         }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -348,10 +1570,95 @@ impl ::protobuf::MessageStatic for Message {
                     Message::get_operate_for_reflect,
                     Message::mut_operate_for_reflect,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "content",
-                    Message::get_content_for_reflect,
-                    Message::mut_content_for_reflect,
+                fields.push(::protobuf::reflect::accessor::make_singular_bytes_accessor::<_>(
+                    "RawBytes",
+                    Message::has_RawBytes,
+                    Message::get_RawBytes,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor::<_, super::request::Request>(
+                    "Request",
+                    Message::has_Request,
+                    Message::get_Request,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor::<_, super::response::Response>(
+                    "Response",
+                    Message::has_Response,
+                    Message::get_Response,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor::<_, super::sync::SyncRequest>(
+                    "SyncRequest",
+                    Message::has_SyncRequest,
+                    Message::get_SyncRequest,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor::<_, super::sync::SyncResponse>(
+                    "SyncResponse",
+                    Message::has_SyncResponse,
+                    Message::get_SyncResponse,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor::<_, super::blockchain::Status>(
+                    "Status",
+                    Message::has_Status,
+                    Message::get_Status,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor::<_, super::blockchain::RichStatus>(
+                    "RichStatus",
+                    Message::has_RichStatus,
+                    Message::get_RichStatus,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor::<_, super::blockchain::Block>(
+                    "Block",
+                    Message::has_Block,
+                    Message::get_Block,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor::<_, super::blockchain::BlockWithProof>(
+                    "BlockWithProof",
+                    Message::has_BlockWithProof,
+                    Message::get_BlockWithProof,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor::<_, super::blockchain::BlockHeader>(
+                    "BlockHeader",
+                    Message::has_BlockHeader,
+                    Message::get_BlockHeader,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor::<_, super::blockchain::BlockTxs>(
+                    "BlockTxs",
+                    Message::has_BlockTxs,
+                    Message::get_BlockTxs,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor::<_, super::auth::BlockTxHashes>(
+                    "BlockTxHashes",
+                    Message::has_BlockTxHashes,
+                    Message::get_BlockTxHashes,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor::<_, super::auth::BlockTxHashesReq>(
+                    "BlockTxHashesReq",
+                    Message::has_BlockTxHashesReq,
+                    Message::get_BlockTxHashesReq,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor::<_, super::auth::VerifyTxReq>(
+                    "VerifyTxReq",
+                    Message::has_VerifyTxReq,
+                    Message::get_VerifyTxReq,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor::<_, super::auth::VerifyTxResp>(
+                    "VerifyTxResp",
+                    Message::has_VerifyTxResp,
+                    Message::get_VerifyTxResp,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor::<_, super::auth::VerifyBlockReq>(
+                    "VerifyBlockReq",
+                    Message::has_VerifyBlockReq,
+                    Message::get_VerifyBlockReq,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor::<_, super::auth::VerifyBlockResp>(
+                    "VerifyBlockResp",
+                    Message::has_VerifyBlockResp,
+                    Message::get_VerifyBlockResp,
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_message_accessor::<_, super::executer::ExecutedResult>(
+                    "ExecutedResult",
+                    Message::has_ExecutedResult,
+                    Message::get_ExecutedResult,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<Message>(
                     "Message",
@@ -369,7 +1676,24 @@ impl ::protobuf::Clear for Message {
         self.clear_field_type();
         self.clear_origin();
         self.clear_operate();
-        self.clear_content();
+        self.clear_RawBytes();
+        self.clear_Request();
+        self.clear_Response();
+        self.clear_SyncRequest();
+        self.clear_SyncResponse();
+        self.clear_Status();
+        self.clear_RichStatus();
+        self.clear_Block();
+        self.clear_BlockWithProof();
+        self.clear_BlockHeader();
+        self.clear_BlockTxs();
+        self.clear_BlockTxHashes();
+        self.clear_BlockTxHashesReq();
+        self.clear_VerifyTxReq();
+        self.clear_VerifyTxResp();
+        self.clear_VerifyBlockReq();
+        self.clear_VerifyBlockResp();
+        self.clear_ExecutedResult();
         self.unknown_fields.clear();
     }
 }
@@ -548,84 +1872,150 @@ impl ::protobuf::reflect::ProtobufValue for OperateType {
 }
 
 static file_descriptor_proto_data: &'static [u8] = b"\
-    \n\x13communication.proto\"\x98\x01\n\x07Message\x12\x15\n\x06cmd_id\x18\
-    \x01\x20\x01(\rR\x05cmdId\x12\x1c\n\x04type\x18\x02\x20\x01(\x0e2\x08.Ms\
-    gTypeR\x04type\x12\x16\n\x06origin\x18\x03\x20\x01(\rR\x06origin\x12&\n\
-    \x07operate\x18\x04\x20\x01(\x0e2\x0c.OperateTypeR\x07operate\x12\x18\n\
-    \x07content\x18\x05\x20\x01(\x0cR\x07content*\xb3\x02\n\x07MsgType\x12\
-    \x0b\n\x07REQUEST\x10\0\x12\n\n\x06HEADER\x10\x01\x12\t\n\x05BLOCK\x10\
-    \x02\x12\n\n\x06STATUS\x10\x03\x12\x07\n\x03MSG\x10\x04\x12\x0c\n\x08RES\
-    PONSE\x10\x05\x12\x11\n\rVERIFY_TX_REQ\x10\x06\x12\x12\n\x0eVERIFY_TX_RE\
-    SP\x10\x07\x12\x12\n\x0eVERIFY_BLK_REQ\x10\x08\x12\x13\n\x0fVERIFY_BLK_R\
-    ESP\x10\t\x12\x12\n\x0eBLOCK_TXHASHES\x10\n\x12\x16\n\x12BLOCK_TXHASHES_\
-    REQ\x10\x0b\x12\x14\n\x10BLOCK_WITH_PROOF\x10\x0c\x12\r\n\tBLOCK_TXS\x10\
-    \r\x12\x0f\n\x0bRICH_STATUS\x10\x0e\x12\x0c\n\x08SYNC_REQ\x10\x0f\x12\
-    \x0c\n\x08SYNC_RES\x10\x10\x12\x13\n\x0fEXECUTED_RESULT\x10\x11*6\n\x0bO\
-    perateType\x12\r\n\tBROADCAST\x10\0\x12\n\n\x06SINGLE\x10\x01\x12\x0c\n\
-    \x08SUBTRACT\x10\x02J\x95\n\n\x06\x12\x04\0\0#\x01\n\x08\n\x01\x0c\x12\
-    \x03\0\0\x12\n\n\n\x02\x05\0\x12\x04\x02\0\x15\x01\n\n\n\x03\x05\0\x01\
-    \x12\x03\x02\x05\x0c\n\x0b\n\x04\x05\0\x02\0\x12\x03\x03\x04\x10\n\x0c\n\
-    \x05\x05\0\x02\0\x01\x12\x03\x03\x04\x0b\n\x0c\n\x05\x05\0\x02\0\x02\x12\
-    \x03\x03\x0e\x0f\n\x0b\n\x04\x05\0\x02\x01\x12\x03\x04\x04\x0f\n\x0c\n\
-    \x05\x05\0\x02\x01\x01\x12\x03\x04\x04\n\n\x0c\n\x05\x05\0\x02\x01\x02\
-    \x12\x03\x04\r\x0e\n\x0b\n\x04\x05\0\x02\x02\x12\x03\x05\x04\x0e\n\x0c\n\
-    \x05\x05\0\x02\x02\x01\x12\x03\x05\x04\t\n\x0c\n\x05\x05\0\x02\x02\x02\
-    \x12\x03\x05\x0c\r\n\x0b\n\x04\x05\0\x02\x03\x12\x03\x06\x04\x0f\n\x0c\n\
-    \x05\x05\0\x02\x03\x01\x12\x03\x06\x04\n\n\x0c\n\x05\x05\0\x02\x03\x02\
-    \x12\x03\x06\r\x0e\n\x0b\n\x04\x05\0\x02\x04\x12\x03\x07\x04\x0c\n\x0c\n\
-    \x05\x05\0\x02\x04\x01\x12\x03\x07\x04\x07\n\x0c\n\x05\x05\0\x02\x04\x02\
-    \x12\x03\x07\n\x0b\n\x0b\n\x04\x05\0\x02\x05\x12\x03\x08\x04\x11\n\x0c\n\
-    \x05\x05\0\x02\x05\x01\x12\x03\x08\x04\x0c\n\x0c\n\x05\x05\0\x02\x05\x02\
-    \x12\x03\x08\x0f\x10\n\x0b\n\x04\x05\0\x02\x06\x12\x03\t\x04\x16\n\x0c\n\
-    \x05\x05\0\x02\x06\x01\x12\x03\t\x04\x11\n\x0c\n\x05\x05\0\x02\x06\x02\
-    \x12\x03\t\x14\x15\n\x0b\n\x04\x05\0\x02\x07\x12\x03\n\x04\x17\n\x0c\n\
-    \x05\x05\0\x02\x07\x01\x12\x03\n\x04\x12\n\x0c\n\x05\x05\0\x02\x07\x02\
-    \x12\x03\n\x15\x16\n\x0b\n\x04\x05\0\x02\x08\x12\x03\x0b\x04\x17\n\x0c\n\
-    \x05\x05\0\x02\x08\x01\x12\x03\x0b\x04\x12\n\x0c\n\x05\x05\0\x02\x08\x02\
-    \x12\x03\x0b\x15\x16\n\x0b\n\x04\x05\0\x02\t\x12\x03\x0c\x04\x18\n\x0c\n\
-    \x05\x05\0\x02\t\x01\x12\x03\x0c\x04\x13\n\x0c\n\x05\x05\0\x02\t\x02\x12\
-    \x03\x0c\x16\x17\n\x0b\n\x04\x05\0\x02\n\x12\x03\r\x04\x18\n\x0c\n\x05\
-    \x05\0\x02\n\x01\x12\x03\r\x04\x12\n\x0c\n\x05\x05\0\x02\n\x02\x12\x03\r\
-    \x15\x17\n\x0b\n\x04\x05\0\x02\x0b\x12\x03\x0e\x04\x1c\n\x0c\n\x05\x05\0\
-    \x02\x0b\x01\x12\x03\x0e\x04\x16\n\x0c\n\x05\x05\0\x02\x0b\x02\x12\x03\
-    \x0e\x19\x1b\n\x0b\n\x04\x05\0\x02\x0c\x12\x03\x0f\x04\x1a\n\x0c\n\x05\
-    \x05\0\x02\x0c\x01\x12\x03\x0f\x04\x14\n\x0c\n\x05\x05\0\x02\x0c\x02\x12\
-    \x03\x0f\x17\x19\n\x0b\n\x04\x05\0\x02\r\x12\x03\x10\x04\x13\n\x0c\n\x05\
-    \x05\0\x02\r\x01\x12\x03\x10\x04\r\n\x0c\n\x05\x05\0\x02\r\x02\x12\x03\
-    \x10\x10\x12\n\x0b\n\x04\x05\0\x02\x0e\x12\x03\x11\x04\x15\n\x0c\n\x05\
-    \x05\0\x02\x0e\x01\x12\x03\x11\x04\x0f\n\x0c\n\x05\x05\0\x02\x0e\x02\x12\
-    \x03\x11\x12\x14\n\x0b\n\x04\x05\0\x02\x0f\x12\x03\x12\x04\x12\n\x0c\n\
-    \x05\x05\0\x02\x0f\x01\x12\x03\x12\x04\x0c\n\x0c\n\x05\x05\0\x02\x0f\x02\
-    \x12\x03\x12\x0f\x11\n\x0b\n\x04\x05\0\x02\x10\x12\x03\x13\x04\x12\n\x0c\
-    \n\x05\x05\0\x02\x10\x01\x12\x03\x13\x04\x0c\n\x0c\n\x05\x05\0\x02\x10\
-    \x02\x12\x03\x13\x0f\x11\n\x0b\n\x04\x05\0\x02\x11\x12\x03\x14\x04\x19\n\
-    \x0c\n\x05\x05\0\x02\x11\x01\x12\x03\x14\x04\x13\n\x0c\n\x05\x05\0\x02\
-    \x11\x02\x12\x03\x14\x16\x18\n\n\n\x02\x05\x01\x12\x04\x17\0\x1b\x01\n\n\
-    \n\x03\x05\x01\x01\x12\x03\x17\x05\x10\n\x0b\n\x04\x05\x01\x02\0\x12\x03\
-    \x18\x04\x12\n\x0c\n\x05\x05\x01\x02\0\x01\x12\x03\x18\x04\r\n\x0c\n\x05\
-    \x05\x01\x02\0\x02\x12\x03\x18\x10\x11\n\x0b\n\x04\x05\x01\x02\x01\x12\
-    \x03\x19\x04\x0f\n\x0c\n\x05\x05\x01\x02\x01\x01\x12\x03\x19\x04\n\n\x0c\
-    \n\x05\x05\x01\x02\x01\x02\x12\x03\x19\r\x0e\n\x0b\n\x04\x05\x01\x02\x02\
-    \x12\x03\x1a\x04\x11\n\x0c\n\x05\x05\x01\x02\x02\x01\x12\x03\x1a\x04\x0c\
-    \n\x0c\n\x05\x05\x01\x02\x02\x02\x12\x03\x1a\x0f\x10\n\n\n\x02\x04\0\x12\
-    \x04\x1d\0#\x01\n\n\n\x03\x04\0\x01\x12\x03\x1d\x08\x0f\n\x0b\n\x04\x04\
-    \0\x02\0\x12\x03\x1e\x04\x16\n\r\n\x05\x04\0\x02\0\x04\x12\x04\x1e\x04\
-    \x1d\x11\n\x0c\n\x05\x04\0\x02\0\x05\x12\x03\x1e\x04\n\n\x0c\n\x05\x04\0\
-    \x02\0\x01\x12\x03\x1e\x0b\x11\n\x0c\n\x05\x04\0\x02\0\x03\x12\x03\x1e\
-    \x14\x15\n\x0b\n\x04\x04\0\x02\x01\x12\x03\x1f\x04\x15\n\r\n\x05\x04\0\
-    \x02\x01\x04\x12\x04\x1f\x04\x1e\x16\n\x0c\n\x05\x04\0\x02\x01\x06\x12\
-    \x03\x1f\x04\x0b\n\x0c\n\x05\x04\0\x02\x01\x01\x12\x03\x1f\x0c\x10\n\x0c\
-    \n\x05\x04\0\x02\x01\x03\x12\x03\x1f\x13\x14\n\x0b\n\x04\x04\0\x02\x02\
-    \x12\x03\x20\x04\x16\n\r\n\x05\x04\0\x02\x02\x04\x12\x04\x20\x04\x1f\x15\
-    \n\x0c\n\x05\x04\0\x02\x02\x05\x12\x03\x20\x04\n\n\x0c\n\x05\x04\0\x02\
-    \x02\x01\x12\x03\x20\x0b\x11\n\x0c\n\x05\x04\0\x02\x02\x03\x12\x03\x20\
-    \x14\x15\n\x0b\n\x04\x04\0\x02\x03\x12\x03!\x04\x1c\n\r\n\x05\x04\0\x02\
-    \x03\x04\x12\x04!\x04\x20\x16\n\x0c\n\x05\x04\0\x02\x03\x06\x12\x03!\x04\
-    \x0f\n\x0c\n\x05\x04\0\x02\x03\x01\x12\x03!\x10\x17\n\x0c\n\x05\x04\0\
-    \x02\x03\x03\x12\x03!\x1a\x1b\n\x0b\n\x04\x04\0\x02\x04\x12\x03\"\x04\
-    \x16\n\r\n\x05\x04\0\x02\x04\x04\x12\x04\"\x04!\x1c\n\x0c\n\x05\x04\0\
-    \x02\x04\x05\x12\x03\"\x04\t\n\x0c\n\x05\x04\0\x02\x04\x01\x12\x03\"\n\
-    \x11\n\x0c\n\x05\x04\0\x02\x04\x03\x12\x03\"\x14\x15b\x06proto3\
+    \n\x13communication.proto\x1a\rrequest.proto\x1a\x0eresponse.proto\x1a\n\
+    sync.proto\x1a\x10blockchain.proto\x1a\nauth.proto\x1a\x0eexecuter.proto\
+    \"\xf9\x07\n\x07Message\x12\x15\n\x06cmd_id\x18\x01\x20\x01(\rR\x05cmdId\
+    \x12\x1c\n\x04type\x18\x02\x20\x01(\x0e2\x08.MsgTypeR\x04type\x12\x16\n\
+    \x06origin\x18\x03\x20\x01(\rR\x06origin\x12&\n\x07operate\x18\x04\x20\
+    \x01(\x0e2\x0c.OperateTypeR\x07operate\x12\x1c\n\x08RawBytes\x18\x05\x20\
+    \x01(\x0cH\0R\x08RawBytes\x12$\n\x07Request\x18\x06\x20\x01(\x0b2\x08.Re\
+    questH\0R\x07Request\x12'\n\x08Response\x18\x07\x20\x01(\x0b2\t.Response\
+    H\0R\x08Response\x120\n\x0bSyncRequest\x18\x08\x20\x01(\x0b2\x0c.SyncReq\
+    uestH\0R\x0bSyncRequest\x123\n\x0cSyncResponse\x18\t\x20\x01(\x0b2\r.Syn\
+    cResponseH\0R\x0cSyncResponse\x12!\n\x06Status\x18\n\x20\x01(\x0b2\x07.S\
+    tatusH\0R\x06Status\x12-\n\nRichStatus\x18\x0b\x20\x01(\x0b2\x0b.RichSta\
+    tusH\0R\nRichStatus\x12\x1e\n\x05Block\x18\x0c\x20\x01(\x0b2\x06.BlockH\
+    \0R\x05Block\x129\n\x0eBlockWithProof\x18\r\x20\x01(\x0b2\x0f.BlockWithP\
+    roofH\0R\x0eBlockWithProof\x120\n\x0bBlockHeader\x18\x0e\x20\x01(\x0b2\
+    \x0c.BlockHeaderH\0R\x0bBlockHeader\x12'\n\x08BlockTxs\x18\x0f\x20\x01(\
+    \x0b2\t.BlockTxsH\0R\x08BlockTxs\x126\n\rBlockTxHashes\x18\x10\x20\x01(\
+    \x0b2\x0e.BlockTxHashesH\0R\rBlockTxHashes\x12?\n\x10BlockTxHashesReq\
+    \x18\x11\x20\x01(\x0b2\x11.BlockTxHashesReqH\0R\x10BlockTxHashesReq\x120\
+    \n\x0bVerifyTxReq\x18\x12\x20\x01(\x0b2\x0c.VerifyTxReqH\0R\x0bVerifyTxR\
+    eq\x123\n\x0cVerifyTxResp\x18\x13\x20\x01(\x0b2\r.VerifyTxRespH\0R\x0cVe\
+    rifyTxResp\x129\n\x0eVerifyBlockReq\x18\x14\x20\x01(\x0b2\x0f.VerifyBloc\
+    kReqH\0R\x0eVerifyBlockReq\x12<\n\x0fVerifyBlockResp\x18\x15\x20\x01(\
+    \x0b2\x10.VerifyBlockRespH\0R\x0fVerifyBlockResp\x129\n\x0eExecutedResul\
+    t\x18\x16\x20\x01(\x0b2\x0f.ExecutedResultH\0R\x0eExecutedResultB\t\n\
+    \x07content*\xb3\x02\n\x07MsgType\x12\x0b\n\x07REQUEST\x10\0\x12\n\n\x06\
+    HEADER\x10\x01\x12\t\n\x05BLOCK\x10\x02\x12\n\n\x06STATUS\x10\x03\x12\
+    \x07\n\x03MSG\x10\x04\x12\x0c\n\x08RESPONSE\x10\x05\x12\x11\n\rVERIFY_TX\
+    _REQ\x10\x06\x12\x12\n\x0eVERIFY_TX_RESP\x10\x07\x12\x12\n\x0eVERIFY_BLK\
+    _REQ\x10\x08\x12\x13\n\x0fVERIFY_BLK_RESP\x10\t\x12\x12\n\x0eBLOCK_TXHAS\
+    HES\x10\n\x12\x16\n\x12BLOCK_TXHASHES_REQ\x10\x0b\x12\x14\n\x10BLOCK_WIT\
+    H_PROOF\x10\x0c\x12\r\n\tBLOCK_TXS\x10\r\x12\x0f\n\x0bRICH_STATUS\x10\
+    \x0e\x12\x0c\n\x08SYNC_REQ\x10\x0f\x12\x0c\n\x08SYNC_RES\x10\x10\x12\x13\
+    \n\x0fEXECUTED_RESULT\x10\x11*6\n\x0bOperateType\x12\r\n\tBROADCAST\x10\
+    \0\x12\n\n\x06SINGLE\x10\x01\x12\x0c\n\x08SUBTRACT\x10\x02J\x8b\x12\n\
+    \x06\x12\x04\0\0F\x01\n\x08\n\x01\x0c\x12\x03\0\0\x12\n\t\n\x02\x03\0\
+    \x12\x03\x02\x07\x16\n\t\n\x02\x03\x01\x12\x03\x03\x07\x17\n\t\n\x02\x03\
+    \x02\x12\x03\x04\x07\x13\n\t\n\x02\x03\x03\x12\x03\x05\x07\x19\n\t\n\x02\
+    \x03\x04\x12\x03\x06\x07\x13\n\t\n\x02\x03\x05\x12\x03\x07\x07\x17\n\n\n\
+    \x02\x05\0\x12\x04\t\0\x1c\x01\n\n\n\x03\x05\0\x01\x12\x03\t\x05\x0c\n\
+    \x0b\n\x04\x05\0\x02\0\x12\x03\n\x04\x10\n\x0c\n\x05\x05\0\x02\0\x01\x12\
+    \x03\n\x04\x0b\n\x0c\n\x05\x05\0\x02\0\x02\x12\x03\n\x0e\x0f\n\x0b\n\x04\
+    \x05\0\x02\x01\x12\x03\x0b\x04\x0f\n\x0c\n\x05\x05\0\x02\x01\x01\x12\x03\
+    \x0b\x04\n\n\x0c\n\x05\x05\0\x02\x01\x02\x12\x03\x0b\r\x0e\n\x0b\n\x04\
+    \x05\0\x02\x02\x12\x03\x0c\x04\x0e\n\x0c\n\x05\x05\0\x02\x02\x01\x12\x03\
+    \x0c\x04\t\n\x0c\n\x05\x05\0\x02\x02\x02\x12\x03\x0c\x0c\r\n\x0b\n\x04\
+    \x05\0\x02\x03\x12\x03\r\x04\x0f\n\x0c\n\x05\x05\0\x02\x03\x01\x12\x03\r\
+    \x04\n\n\x0c\n\x05\x05\0\x02\x03\x02\x12\x03\r\r\x0e\n\x0b\n\x04\x05\0\
+    \x02\x04\x12\x03\x0e\x04\x0c\n\x0c\n\x05\x05\0\x02\x04\x01\x12\x03\x0e\
+    \x04\x07\n\x0c\n\x05\x05\0\x02\x04\x02\x12\x03\x0e\n\x0b\n\x0b\n\x04\x05\
+    \0\x02\x05\x12\x03\x0f\x04\x11\n\x0c\n\x05\x05\0\x02\x05\x01\x12\x03\x0f\
+    \x04\x0c\n\x0c\n\x05\x05\0\x02\x05\x02\x12\x03\x0f\x0f\x10\n\x0b\n\x04\
+    \x05\0\x02\x06\x12\x03\x10\x04\x16\n\x0c\n\x05\x05\0\x02\x06\x01\x12\x03\
+    \x10\x04\x11\n\x0c\n\x05\x05\0\x02\x06\x02\x12\x03\x10\x14\x15\n\x0b\n\
+    \x04\x05\0\x02\x07\x12\x03\x11\x04\x17\n\x0c\n\x05\x05\0\x02\x07\x01\x12\
+    \x03\x11\x04\x12\n\x0c\n\x05\x05\0\x02\x07\x02\x12\x03\x11\x15\x16\n\x0b\
+    \n\x04\x05\0\x02\x08\x12\x03\x12\x04\x17\n\x0c\n\x05\x05\0\x02\x08\x01\
+    \x12\x03\x12\x04\x12\n\x0c\n\x05\x05\0\x02\x08\x02\x12\x03\x12\x15\x16\n\
+    \x0b\n\x04\x05\0\x02\t\x12\x03\x13\x04\x18\n\x0c\n\x05\x05\0\x02\t\x01\
+    \x12\x03\x13\x04\x13\n\x0c\n\x05\x05\0\x02\t\x02\x12\x03\x13\x16\x17\n\
+    \x0b\n\x04\x05\0\x02\n\x12\x03\x14\x04\x18\n\x0c\n\x05\x05\0\x02\n\x01\
+    \x12\x03\x14\x04\x12\n\x0c\n\x05\x05\0\x02\n\x02\x12\x03\x14\x15\x17\n\
+    \x0b\n\x04\x05\0\x02\x0b\x12\x03\x15\x04\x1c\n\x0c\n\x05\x05\0\x02\x0b\
+    \x01\x12\x03\x15\x04\x16\n\x0c\n\x05\x05\0\x02\x0b\x02\x12\x03\x15\x19\
+    \x1b\n\x0b\n\x04\x05\0\x02\x0c\x12\x03\x16\x04\x1a\n\x0c\n\x05\x05\0\x02\
+    \x0c\x01\x12\x03\x16\x04\x14\n\x0c\n\x05\x05\0\x02\x0c\x02\x12\x03\x16\
+    \x17\x19\n\x0b\n\x04\x05\0\x02\r\x12\x03\x17\x04\x13\n\x0c\n\x05\x05\0\
+    \x02\r\x01\x12\x03\x17\x04\r\n\x0c\n\x05\x05\0\x02\r\x02\x12\x03\x17\x10\
+    \x12\n\x0b\n\x04\x05\0\x02\x0e\x12\x03\x18\x04\x15\n\x0c\n\x05\x05\0\x02\
+    \x0e\x01\x12\x03\x18\x04\x0f\n\x0c\n\x05\x05\0\x02\x0e\x02\x12\x03\x18\
+    \x12\x14\n\x0b\n\x04\x05\0\x02\x0f\x12\x03\x19\x04\x12\n\x0c\n\x05\x05\0\
+    \x02\x0f\x01\x12\x03\x19\x04\x0c\n\x0c\n\x05\x05\0\x02\x0f\x02\x12\x03\
+    \x19\x0f\x11\n\x0b\n\x04\x05\0\x02\x10\x12\x03\x1a\x04\x12\n\x0c\n\x05\
+    \x05\0\x02\x10\x01\x12\x03\x1a\x04\x0c\n\x0c\n\x05\x05\0\x02\x10\x02\x12\
+    \x03\x1a\x0f\x11\n\x0b\n\x04\x05\0\x02\x11\x12\x03\x1b\x04\x19\n\x0c\n\
+    \x05\x05\0\x02\x11\x01\x12\x03\x1b\x04\x13\n\x0c\n\x05\x05\0\x02\x11\x02\
+    \x12\x03\x1b\x16\x18\n\n\n\x02\x05\x01\x12\x04\x1e\0\"\x01\n\n\n\x03\x05\
+    \x01\x01\x12\x03\x1e\x05\x10\n\x0b\n\x04\x05\x01\x02\0\x12\x03\x1f\x04\
+    \x12\n\x0c\n\x05\x05\x01\x02\0\x01\x12\x03\x1f\x04\r\n\x0c\n\x05\x05\x01\
+    \x02\0\x02\x12\x03\x1f\x10\x11\n\x0b\n\x04\x05\x01\x02\x01\x12\x03\x20\
+    \x04\x0f\n\x0c\n\x05\x05\x01\x02\x01\x01\x12\x03\x20\x04\n\n\x0c\n\x05\
+    \x05\x01\x02\x01\x02\x12\x03\x20\r\x0e\n\x0b\n\x04\x05\x01\x02\x02\x12\
+    \x03!\x04\x11\n\x0c\n\x05\x05\x01\x02\x02\x01\x12\x03!\x04\x0c\n\x0c\n\
+    \x05\x05\x01\x02\x02\x02\x12\x03!\x0f\x10\n\n\n\x02\x04\0\x12\x04$\0F\
+    \x01\n\n\n\x03\x04\0\x01\x12\x03$\x08\x0f\n\x0b\n\x04\x04\0\x02\0\x12\
+    \x03%\x04\x16\n\r\n\x05\x04\0\x02\0\x04\x12\x04%\x04$\x11\n\x0c\n\x05\
+    \x04\0\x02\0\x05\x12\x03%\x04\n\n\x0c\n\x05\x04\0\x02\0\x01\x12\x03%\x0b\
+    \x11\n\x0c\n\x05\x04\0\x02\0\x03\x12\x03%\x14\x15\n\x0b\n\x04\x04\0\x02\
+    \x01\x12\x03&\x04\x15\n\r\n\x05\x04\0\x02\x01\x04\x12\x04&\x04%\x16\n\
+    \x0c\n\x05\x04\0\x02\x01\x06\x12\x03&\x04\x0b\n\x0c\n\x05\x04\0\x02\x01\
+    \x01\x12\x03&\x0c\x10\n\x0c\n\x05\x04\0\x02\x01\x03\x12\x03&\x13\x14\n\
+    \x0b\n\x04\x04\0\x02\x02\x12\x03'\x04\x16\n\r\n\x05\x04\0\x02\x02\x04\
+    \x12\x04'\x04&\x15\n\x0c\n\x05\x04\0\x02\x02\x05\x12\x03'\x04\n\n\x0c\n\
+    \x05\x04\0\x02\x02\x01\x12\x03'\x0b\x11\n\x0c\n\x05\x04\0\x02\x02\x03\
+    \x12\x03'\x14\x15\n\x0b\n\x04\x04\0\x02\x03\x12\x03(\x04\x1c\n\r\n\x05\
+    \x04\0\x02\x03\x04\x12\x04(\x04'\x16\n\x0c\n\x05\x04\0\x02\x03\x06\x12\
+    \x03(\x04\x0f\n\x0c\n\x05\x04\0\x02\x03\x01\x12\x03(\x10\x17\n\x0c\n\x05\
+    \x04\0\x02\x03\x03\x12\x03(\x1a\x1b\n\x0c\n\x04\x04\0\x08\0\x12\x04*\x04\
+    E\x05\n\x0c\n\x05\x04\0\x08\0\x01\x12\x03*\n\x11\n\x0b\n\x04\x04\0\x02\
+    \x04\x12\x03,\x08\x1b\n\x0c\n\x05\x04\0\x02\x04\x05\x12\x03,\x08\r\n\x0c\
+    \n\x05\x04\0\x02\x04\x01\x12\x03,\x0e\x16\n\x0c\n\x05\x04\0\x02\x04\x03\
+    \x12\x03,\x19\x1a\n\x0b\n\x04\x04\0\x02\x05\x12\x03.\x08\x1c\n\x0c\n\x05\
+    \x04\0\x02\x05\x06\x12\x03.\x08\x0f\n\x0c\n\x05\x04\0\x02\x05\x01\x12\
+    \x03.\x10\x17\n\x0c\n\x05\x04\0\x02\x05\x03\x12\x03.\x1a\x1b\n\x0b\n\x04\
+    \x04\0\x02\x06\x12\x03/\x08\x1e\n\x0c\n\x05\x04\0\x02\x06\x06\x12\x03/\
+    \x08\x10\n\x0c\n\x05\x04\0\x02\x06\x01\x12\x03/\x11\x19\n\x0c\n\x05\x04\
+    \0\x02\x06\x03\x12\x03/\x1c\x1d\n\x0b\n\x04\x04\0\x02\x07\x12\x031\x08$\
+    \n\x0c\n\x05\x04\0\x02\x07\x06\x12\x031\x08\x13\n\x0c\n\x05\x04\0\x02\
+    \x07\x01\x12\x031\x14\x1f\n\x0c\n\x05\x04\0\x02\x07\x03\x12\x031\"#\n\
+    \x0b\n\x04\x04\0\x02\x08\x12\x032\x08&\n\x0c\n\x05\x04\0\x02\x08\x06\x12\
+    \x032\x08\x14\n\x0c\n\x05\x04\0\x02\x08\x01\x12\x032\x15!\n\x0c\n\x05\
+    \x04\0\x02\x08\x03\x12\x032$%\n\x0b\n\x04\x04\0\x02\t\x12\x034\x08\x1b\n\
+    \x0c\n\x05\x04\0\x02\t\x06\x12\x034\x08\x0e\n\x0c\n\x05\x04\0\x02\t\x01\
+    \x12\x034\x0f\x15\n\x0c\n\x05\x04\0\x02\t\x03\x12\x034\x18\x1a\n\x0b\n\
+    \x04\x04\0\x02\n\x12\x035\x08#\n\x0c\n\x05\x04\0\x02\n\x06\x12\x035\x08\
+    \x12\n\x0c\n\x05\x04\0\x02\n\x01\x12\x035\x13\x1d\n\x0c\n\x05\x04\0\x02\
+    \n\x03\x12\x035\x20\"\n\x0b\n\x04\x04\0\x02\x0b\x12\x037\x08\x19\n\x0c\n\
+    \x05\x04\0\x02\x0b\x06\x12\x037\x08\r\n\x0c\n\x05\x04\0\x02\x0b\x01\x12\
+    \x037\x0e\x13\n\x0c\n\x05\x04\0\x02\x0b\x03\x12\x037\x16\x18\n\x0b\n\x04\
+    \x04\0\x02\x0c\x12\x038\x08+\n\x0c\n\x05\x04\0\x02\x0c\x06\x12\x038\x08\
+    \x16\n\x0c\n\x05\x04\0\x02\x0c\x01\x12\x038\x17%\n\x0c\n\x05\x04\0\x02\
+    \x0c\x03\x12\x038(*\n\x0b\n\x04\x04\0\x02\r\x12\x039\x08%\n\x0c\n\x05\
+    \x04\0\x02\r\x06\x12\x039\x08\x13\n\x0c\n\x05\x04\0\x02\r\x01\x12\x039\
+    \x14\x1f\n\x0c\n\x05\x04\0\x02\r\x03\x12\x039\"$\n\x0b\n\x04\x04\0\x02\
+    \x0e\x12\x03:\x08\x1f\n\x0c\n\x05\x04\0\x02\x0e\x06\x12\x03:\x08\x10\n\
+    \x0c\n\x05\x04\0\x02\x0e\x01\x12\x03:\x11\x19\n\x0c\n\x05\x04\0\x02\x0e\
+    \x03\x12\x03:\x1c\x1e\n\x0b\n\x04\x04\0\x02\x0f\x12\x03<\x08)\n\x0c\n\
+    \x05\x04\0\x02\x0f\x06\x12\x03<\x08\x15\n\x0c\n\x05\x04\0\x02\x0f\x01\
+    \x12\x03<\x16#\n\x0c\n\x05\x04\0\x02\x0f\x03\x12\x03<&(\n\x0b\n\x04\x04\
+    \0\x02\x10\x12\x03=\x08/\n\x0c\n\x05\x04\0\x02\x10\x06\x12\x03=\x08\x18\
+    \n\x0c\n\x05\x04\0\x02\x10\x01\x12\x03=\x19)\n\x0c\n\x05\x04\0\x02\x10\
+    \x03\x12\x03=,.\n\x0b\n\x04\x04\0\x02\x11\x12\x03?\x08%\n\x0c\n\x05\x04\
+    \0\x02\x11\x06\x12\x03?\x08\x13\n\x0c\n\x05\x04\0\x02\x11\x01\x12\x03?\
+    \x14\x1f\n\x0c\n\x05\x04\0\x02\x11\x03\x12\x03?\"$\n\x0b\n\x04\x04\0\x02\
+    \x12\x12\x03@\x08'\n\x0c\n\x05\x04\0\x02\x12\x06\x12\x03@\x08\x14\n\x0c\
+    \n\x05\x04\0\x02\x12\x01\x12\x03@\x15!\n\x0c\n\x05\x04\0\x02\x12\x03\x12\
+    \x03@$&\n\x0b\n\x04\x04\0\x02\x13\x12\x03A\x08+\n\x0c\n\x05\x04\0\x02\
+    \x13\x06\x12\x03A\x08\x16\n\x0c\n\x05\x04\0\x02\x13\x01\x12\x03A\x17%\n\
+    \x0c\n\x05\x04\0\x02\x13\x03\x12\x03A(*\n\x0b\n\x04\x04\0\x02\x14\x12\
+    \x03B\x08-\n\x0c\n\x05\x04\0\x02\x14\x06\x12\x03B\x08\x17\n\x0c\n\x05\
+    \x04\0\x02\x14\x01\x12\x03B\x18'\n\x0c\n\x05\x04\0\x02\x14\x03\x12\x03B*\
+    ,\n\x0b\n\x04\x04\0\x02\x15\x12\x03D\x08+\n\x0c\n\x05\x04\0\x02\x15\x06\
+    \x12\x03D\x08\x16\n\x0c\n\x05\x04\0\x02\x15\x01\x12\x03D\x17%\n\x0c\n\
+    \x05\x04\0\x02\x15\x03\x12\x03D(*b\x06proto3\
 ";
 
 static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {

--- a/libproto/src/communication.rs
+++ b/libproto/src/communication.rs
@@ -1,5 +1,5 @@
 // CITA
-// Copyright 2016-2017 Cryptape Technologies LLC.
+// Copyright 2016-2018 Cryptape Technologies LLC.
 
 // This program is free software: you can redistribute it
 // and/or modify it under the terms of the GNU General Public
@@ -14,6 +14,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 // This file is generated. Do not edit
 // @generated
 

--- a/libproto/src/consensus.rs
+++ b/libproto/src/consensus.rs
@@ -1,5 +1,5 @@
 // CITA
-// Copyright 2016-2017 Cryptape Technologies LLC.
+// Copyright 2016-2018 Cryptape Technologies LLC.
 
 // This program is free software: you can redistribute it
 // and/or modify it under the terms of the GNU General Public
@@ -14,6 +14,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 // This file is generated. Do not edit
 // @generated
 

--- a/libproto/src/create_protobuf.sh
+++ b/libproto/src/create_protobuf.sh
@@ -1,19 +1,15 @@
 #!/bin/bash
-protoc blockchain.proto --rust_out .
-protoc communication.proto --rust_out .
-protoc auth.proto --rust_out .
-protoc request.proto --rust_out .
-protoc response.proto --rust_out .
-protoc consensus.proto --rust_out .
-protoc sync.proto --rust_out .
-protoc executer.proto --rust_out .
+
+find . -name "*.proto" | while read protofile; do
+    protoc ${protofile} --rust_out .
+done
 
 case "$OSTYPE" in
-    darwin*)  
+    darwin*)
         sed -ig 's/    data: ::std::option::Option<Response_oneof_data>,/    pub data: ::std::option::Option<Response_oneof_data>,/g' response.rs
         sed -ig 's/    req: ::std::option::Option<Request_oneof_req>,/    pub req: ::std::option::Option<Request_oneof_req>,/g' request.rs
-        ;; 
-    *)       
+        ;;
+    *)
         sed -i 's/    data: ::std::option::Option<Response_oneof_data>,/    pub data: ::std::option::Option<Response_oneof_data>,/g' response.rs
         sed -i 's/    req: ::std::option::Option<Request_oneof_req>,/    pub req: ::std::option::Option<Request_oneof_req>,/g' request.rs
         ;;
@@ -21,11 +17,11 @@ esac
 
 for i in `find . -name "*.rs"`
 do
-    if grep -q -e "Copyright 2015-2017 Parity Technologies" -e "Copyright 2016-2017 Cryptape Technologies" $i
+    if grep -q -e "Copyright 2015-20.. Parity Technologies" -e "Copyright 2016-20.. Cryptape Technologies" $i
     then
         echo "Ignoring the " $i
     else
         echo "Starting modify" $i
-        (cat ../../../publishtool/notices | cat - $i > file1) && mv file1 $i
+        (cat ../../LICENSE_HEADER | cat - $i > file1) && mv file1 $i
     fi
 done

--- a/libproto/src/executer.rs
+++ b/libproto/src/executer.rs
@@ -1,5 +1,5 @@
 // CITA
-// Copyright 2016-2017 Cryptape Technologies LLC.
+// Copyright 2016-2018 Cryptape Technologies LLC.
 
 // This program is free software: you can redistribute it
 // and/or modify it under the terms of the GNU General Public
@@ -14,6 +14,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 // This file is generated. Do not edit
 // @generated
 

--- a/libproto/src/into.rs
+++ b/libproto/src/into.rs
@@ -18,7 +18,6 @@
 use super::*;
 use blockchain::{RichStatus, Status};
 use communication;
-use protobuf::Message;
 use submodules;
 use topics;
 
@@ -28,7 +27,7 @@ impl Into<communication::Message> for Request {
             submodules::JSON_RPC,
             topics::REQUEST,
             communication::MsgType::REQUEST,
-            self.write_to_bytes().unwrap(),
+            MsgClass::REQUEST(self),
         );
         msg
     }
@@ -52,7 +51,7 @@ impl Into<communication::Message> for Response {
             submodules::CHAIN,
             topics::RESPONSE,
             communication::MsgType::RESPONSE,
-            self.write_to_bytes().unwrap(),
+            MsgClass::RESPONSE(self),
         );
         msg
     }

--- a/libproto/src/into.rs
+++ b/libproto/src/into.rs
@@ -1,5 +1,5 @@
 // CITA
-// Copyright 2016-2017 Cryptape Technologies LLC.
+// Copyright 2016-2018 Cryptape Technologies LLC.
 
 // This program is free software: you can redistribute it
 // and/or modify it under the terms of the GNU General Public

--- a/libproto/src/lib.rs
+++ b/libproto/src/lib.rs
@@ -213,7 +213,7 @@ pub mod factory {
         msg.set_operate(communication::OperateType::BROADCAST);
         msg.set_origin(ZERO_ORIGIN);
         //compress data
-        msg.set_content(snappy::cita_compresse(content));
+        msg.set_content(snappy::cita_compress(content));
         msg
     }
 

--- a/libproto/src/lib.rs
+++ b/libproto/src/lib.rs
@@ -1,5 +1,5 @@
 // CITA
-// Copyright 2016-2017 Cryptape Technologies LLC.
+// Copyright 2016-2018 Cryptape Technologies LLC.
 
 // This program is free software: you can redistribute it
 // and/or modify it under the terms of the GNU General Public

--- a/libproto/src/lib.rs
+++ b/libproto/src/lib.rs
@@ -50,8 +50,7 @@ use rustc_serialize::hex::ToHex;
 use std::ops::Deref;
 use std::result::Result::Err;
 pub use sync::{SyncRequest, SyncResponse};
-use util::{merklehash, H256, Hashable};
-use util::snappy;
+use util::{merklehash, snappy, H256, Hashable};
 
 //TODO respone contain error
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -206,14 +205,32 @@ pub mod factory {
     use super::*;
     pub const ZERO_ORIGIN: u32 = 99999;
 
-    pub fn create_msg(sub: u32, top: u16, msg_type: MsgType, content: Vec<u8>) -> communication::Message {
+    pub fn create_msg(sub: u32, top: u16, msg_type: MsgType, msg_class: MsgClass) -> communication::Message {
         let mut msg = communication::Message::new();
         msg.set_cmd_id(cmd_id(sub, top));
         msg.set_field_type(msg_type);
         msg.set_operate(communication::OperateType::BROADCAST);
         msg.set_origin(ZERO_ORIGIN);
-        //compress data
-        msg.set_content(snappy::cita_compress(content));
+        match msg_class {
+            MsgClass::MSG(data) => msg.set_RawBytes(snappy::cita_compress(data)),
+            MsgClass::REQUEST(data) => msg.set_Request(data),
+            MsgClass::RESPONSE(data) => msg.set_Response(data),
+            MsgClass::SYNCREQUEST(data) => msg.set_SyncRequest(data),
+            MsgClass::SYNCRESPONSE(data) => msg.set_SyncResponse(data),
+            MsgClass::STATUS(data) => msg.set_Status(data),
+            MsgClass::RICHSTATUS(data) => msg.set_RichStatus(data),
+            MsgClass::BLOCK(data) => msg.set_Block(data),
+            MsgClass::BLOCKWITHPROOF(data) => msg.set_BlockWithProof(data),
+            MsgClass::HEADER(data) => msg.set_BlockHeader(data),
+            MsgClass::BLOCKTXS(data) => msg.set_BlockTxs(data),
+            MsgClass::BLOCKTXHASHES(data) => msg.set_BlockTxHashes(data),
+            MsgClass::BLOCKTXHASHESREQ(data) => msg.set_BlockTxHashesReq(data),
+            MsgClass::VERIFYTXREQ(data) => msg.set_VerifyTxReq(data),
+            MsgClass::VERIFYTXRESP(data) => msg.set_VerifyTxResp(data),
+            MsgClass::VERIFYBLKREQ(data) => msg.set_VerifyBlockReq(data),
+            MsgClass::VERIFYBLKRESP(data) => msg.set_VerifyBlockResp(data),
+            MsgClass::EXECUTED(data) => msg.set_ExecutedResult(data),
+        };
         msg
     }
 
@@ -224,9 +241,9 @@ pub mod factory {
         msg_type: MsgType,
         operate: communication::OperateType,
         origin: u32,
-        content: Vec<u8>,
+        msg_class: MsgClass,
     ) -> communication::Message {
-        let mut msg = factory::create_msg(sub, top, msg_type, content);
+        let mut msg = factory::create_msg(sub, top, msg_type, msg_class);
         msg.set_origin(origin);
         msg.set_operate(operate);
         msg
@@ -237,39 +254,34 @@ type CmdId = u32;
 pub type Origin = u32;
 
 pub fn parse_msg(msg: &[u8]) -> (CmdId, Origin, MsgClass) {
-    let mut msg = parse_from_bytes::<communication::Message>(msg.as_ref()).unwrap();
-    let content_msg = msg.take_content();
-    let content_msg = snappy::cita_decompress(content_msg);
-    let msg_class = match msg.get_field_type() {
-        MsgType::REQUEST => MsgClass::REQUEST(parse_from_bytes::<Request>(&content_msg).unwrap()),
-        MsgType::RESPONSE => MsgClass::RESPONSE(parse_from_bytes::<Response>(&content_msg).unwrap()),
-        MsgType::HEADER => MsgClass::HEADER(parse_from_bytes::<BlockHeader>(&content_msg).unwrap()),
-        MsgType::BLOCK => MsgClass::BLOCK(parse_from_bytes::<Block>(&content_msg).unwrap()),
-        MsgType::STATUS => MsgClass::STATUS(parse_from_bytes::<Status>(&content_msg).unwrap()),
-        MsgType::VERIFY_TX_REQ => MsgClass::VERIFYTXREQ(parse_from_bytes::<VerifyTxReq>(&content_msg).unwrap()),
-        MsgType::VERIFY_TX_RESP => MsgClass::VERIFYTXRESP(parse_from_bytes::<VerifyTxResp>(&content_msg).unwrap()),
-        MsgType::VERIFY_BLK_REQ => MsgClass::VERIFYBLKREQ(parse_from_bytes::<VerifyBlockReq>(&content_msg).unwrap()),
-        MsgType::VERIFY_BLK_RESP => MsgClass::VERIFYBLKRESP(parse_from_bytes::<VerifyBlockResp>(&content_msg).unwrap()),
-        MsgType::BLOCK_TXHASHES => MsgClass::BLOCKTXHASHES(parse_from_bytes::<BlockTxHashes>(&content_msg).unwrap()),
-        MsgType::BLOCK_TXHASHES_REQ => {
-            MsgClass::BLOCKTXHASHESREQ(parse_from_bytes::<BlockTxHashesReq>(&content_msg).unwrap())
-        }
-        MsgType::BLOCK_WITH_PROOF => {
-            MsgClass::BLOCKWITHPROOF(parse_from_bytes::<BlockWithProof>(&content_msg).unwrap())
-        }
-        MsgType::BLOCK_TXS => MsgClass::BLOCKTXS(parse_from_bytes::<BlockTxs>(&content_msg).unwrap()),
-        MsgType::MSG => {
+    let msg = parse_from_bytes::<communication::Message>(msg.as_ref()).unwrap();
+    let cmd_id = msg.get_cmd_id();
+    let origin = msg.get_origin();
+    let msg_class = match msg.content.unwrap() {
+        Message_oneof_content::RawBytes(data) => {
             let mut content = Vec::new();
-            content.extend_from_slice(&content_msg);
+            content.extend_from_slice(&snappy::cita_decompress(data));
             MsgClass::MSG(content)
         }
-        MsgType::RICH_STATUS => MsgClass::RICHSTATUS(parse_from_bytes::<RichStatus>(&content_msg).unwrap()),
-        MsgType::SYNC_REQ => MsgClass::SYNCREQUEST(parse_from_bytes::<SyncRequest>(&content_msg).unwrap()),
-        MsgType::SYNC_RES => MsgClass::SYNCRESPONSE(parse_from_bytes::<SyncResponse>(&content_msg).unwrap()),
-        MsgType::EXECUTED_RESULT => MsgClass::EXECUTED(parse_from_bytes::<ExecutedResult>(&content_msg).unwrap()),
+        Message_oneof_content::Request(data) => MsgClass::REQUEST(data),
+        Message_oneof_content::Response(data) => MsgClass::RESPONSE(data),
+        Message_oneof_content::SyncRequest(data) => MsgClass::SYNCREQUEST(data),
+        Message_oneof_content::SyncResponse(data) => MsgClass::SYNCRESPONSE(data),
+        Message_oneof_content::Status(data) => MsgClass::STATUS(data),
+        Message_oneof_content::RichStatus(data) => MsgClass::RICHSTATUS(data),
+        Message_oneof_content::Block(data) => MsgClass::BLOCK(data),
+        Message_oneof_content::BlockWithProof(data) => MsgClass::BLOCKWITHPROOF(data),
+        Message_oneof_content::BlockHeader(data) => MsgClass::HEADER(data),
+        Message_oneof_content::BlockTxs(data) => MsgClass::BLOCKTXS(data),
+        Message_oneof_content::BlockTxHashes(data) => MsgClass::BLOCKTXHASHES(data),
+        Message_oneof_content::BlockTxHashesReq(data) => MsgClass::BLOCKTXHASHESREQ(data),
+        Message_oneof_content::VerifyTxReq(data) => MsgClass::VERIFYTXREQ(data),
+        Message_oneof_content::VerifyTxResp(data) => MsgClass::VERIFYTXRESP(data),
+        Message_oneof_content::VerifyBlockReq(data) => MsgClass::VERIFYBLKREQ(data),
+        Message_oneof_content::VerifyBlockResp(data) => MsgClass::VERIFYBLKRESP(data),
+        Message_oneof_content::ExecutedResult(data) => MsgClass::EXECUTED(data),
     };
-
-    (msg.get_cmd_id(), msg.get_origin(), msg_class)
+    (cmd_id, origin, msg_class)
 }
 
 impl blockchain::Transaction {

--- a/libproto/src/request.rs
+++ b/libproto/src/request.rs
@@ -1,20 +1,20 @@
-// CITA 
-// Copyright 2016-2017 Cryptape Technologies LLC. 
- 
-// This program is free software: you can redistribute it 
-// and/or modify it under the terms of the GNU General Public 
-// License as published by the Free Software Foundation, 
-// either version 3 of the License, or (at your option) any 
-// later version. 
- 
-// This program is distributed in the hope that it will be 
-// useful, but WITHOUT ANY WARRANTY; without even the implied 
-// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
-// PURPOSE. See the GNU General Public License for more details. 
- 
-// You should have received a copy of the GNU General Public License 
-// along with this program.  If not, see <http://www.gnu.org/licenses/>. 
- 
+// CITA
+// Copyright 2016-2018 Cryptape Technologies LLC.
+
+// This program is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any
+// later version.
+
+// This program is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied
+// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 // This file is generated. Do not edit
 // @generated
 

--- a/libproto/src/response.rs
+++ b/libproto/src/response.rs
@@ -1,5 +1,5 @@
 // CITA
-// Copyright 2016-2017 Cryptape Technologies LLC.
+// Copyright 2016-2018 Cryptape Technologies LLC.
 
 // This program is free software: you can redistribute it
 // and/or modify it under the terms of the GNU General Public

--- a/libproto/src/sync.rs
+++ b/libproto/src/sync.rs
@@ -1,5 +1,5 @@
 // CITA
-// Copyright 2016-2017 Cryptape Technologies LLC.
+// Copyright 2016-2018 Cryptape Technologies LLC.
 
 // This program is free software: you can redistribute it
 // and/or modify it under the terms of the GNU General Public

--- a/util/src/snappy.rs
+++ b/util/src/snappy.rs
@@ -150,7 +150,7 @@ pub fn validate_compressed_buffer(input: &[u8]) -> bool {
 }
 
 const CITA_COMPRESS_SIZE: usize = 40 * 1024;
-pub fn cita_compresse(input: Vec<u8>) -> Vec<u8> {
+pub fn cita_compress(input: Vec<u8>) -> Vec<u8> {
     if input.len() > CITA_COMPRESS_SIZE {
         compress(&input)
     } else {


### PR DESCRIPTION
For #8.
1st Step:  Use oneof to instead of explicit serializations in Message.