### PR TITLE
Add code coverage report

### DIFF
--- a/.ci-scripts/coverage
+++ b/.ci-scripts/coverage
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -xe
+
+SCRIPT_PATH=`readlink -f $0`
+source "$(dirname "${SCRIPT_PATH}")/library"
+
+loop_run_in_docker coverage

--- a/.ci-scripts/library
+++ b/.ci-scripts/library
@@ -10,12 +10,13 @@ WORKDIR=/data/work
 
 function run_in_docker () {
     docker run --rm \
-        --volume "${SRCDIR}:${WORKDIR}" \
-        --volume "rust-git:${DOCKER_CARGO_HOME}/git" \
-        --volume "rust-registry:${DOCKER_CARGO_HOME}/registry" \
-        --workdir "${WORKDIR}" \
-        "${DOCKER_IMAGE}" \
-        "$@"
+           -e CODECOV_TOKEN=$CODECOV_TOKEN \
+           --volume "${SRCDIR}:${WORKDIR}" \
+           --volume "rust-git:${DOCKER_CARGO_HOME}/git" \
+           --volume "rust-registry:${DOCKER_CARGO_HOME}/registry" \
+           --workdir "${WORKDIR}" \
+           "${DOCKER_IMAGE}" \
+           "$@"
 }
 
 function cargo_run_in_docker () {

--- a/.ci-scripts/loop_crates_to_run
+++ b/.ci-scripts/loop_crates_to_run
@@ -36,10 +36,32 @@ function cargo_run_build () {
     CARGO_COMMAND=
 }
 
+function cargo_run_coverage () {
+    # For: check_crates_list()
+    CARGO_COMMAND="echo"
+    cargo_run_all
+    CARGO_COMMAND=
+
+    KCOV_TARGET="target/cov"
+    KCOV_FLAGS="--verify"
+    EXCLUDE="/usr/lib,/usr/include,$HOME/.cargo,$HOME/.multirust,rocksdb,secp256k1"
+    mkdir -p $KCOV_TARGET
+    echo "Cover RUST"
+    for FILE in `find target/debug -maxdepth 1 -perm -111 -type f ! -name "*.*"`
+    do
+        echo "[kcov]: ${FILE}"
+        kcov --exclude-pattern $EXCLUDE $KCOV_FLAGS $KCOV_TARGET $FILE || true
+    done
+    echo "kcov Done"
+    bash <(curl -s https://codecov.io/bash) && echo "Uploaded code coverage"
+}
+
 function cargo_run_test () {
+    export RUSTFLAGS="-C link-dead-code"
     CARGO_COMMAND="cargo test --lib"
     cargo_run_all
     CARGO_COMMAND=
+    unset RUSTFLAGS
 }
 
 function cargo_run () {

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache:
   timeout: 600
   directories:
   - $HOME/.cargo
-  - $TRAVIS_BUILD_DIR/target
+  - $TRAVIS_BUILD_DIR/target/debug/deps
 services:
   - docker
 jobs:
@@ -13,8 +13,8 @@ jobs:
       script:
         - docker pull cita/cita-build:latest
         - bash '.ci-scripts/format'
-        - bash '.ci-scripts/build'
         - bash '.ci-scripts/test'
+        - bash '.ci-scripts/coverage'
 before_cache:
     - sudo chown -R travis:travis $HOME/.cargo
-    - sudo chown -R travis:travis $TRAVIS_BUILD_DIR/target
+    - sudo chown -R travis:travis $TRAVIS_BUILD_DIR/target/debug/deps


### PR DESCRIPTION
* Use `kcov` to generate report
* Use `codecov` to show the report

## How coverage report works?
* Generate every test binary files by `cargo test --lib ${features} ${crate}`
* Generate `kcov` report for every {crate, features} by `kcov --exclude-pattern $EXCLUDE $KCOV_FLAGS $KCOV_TARGET $FILE`. `kcov` will automatic merge all reports.
* Upload report to `codecov.io` by `bash <(curl -s https://codecov.io/bash)`. This script will search file like `cobertura.xml`, `coverage.json`.