### PR TITLE
WIP: refactoring pubsub interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "pubsub_rabbitmq",
     "pubsub_kafka",
     "pubsub",
+    "message_queue",
 
     "ethcore-bloom-journal",
     "sha3",

--- a/message_queue/Cargo.toml
+++ b/message_queue/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "message_queue"
+version = "0.6.0"
+authors = ["Cryptape Technologies <contact@cryptape.com>"]

--- a/message_queue/src/channel.rs
+++ b/message_queue/src/channel.rs
@@ -1,0 +1,33 @@
+// CITA
+// Copyright 2016-2017 Cryptape Technologies LLC.
+
+// This program is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any
+// later version.
+
+// This program is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied
+// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pub trait Message {
+    fn msg_type(&self) -> &str;
+    fn to_bytes(&self) -> Vec<u8>;
+}
+
+pub enum Type {
+    Broadcast,
+    Queue,
+}
+
+pub trait Channel {
+    fn ack(&self, msg: &Message);
+    fn sub(&self, f: &Fn(&Message));
+    fn publish(&self, msg: &Message);
+}
+

--- a/message_queue/src/channel.rs
+++ b/message_queue/src/channel.rs
@@ -17,14 +17,14 @@
 
 use std;
 
-pub struct MQMessage {
+pub struct Message {
     pub routing_key: String,
     pub msg_type: String,
     pub payload: Vec<u8>,
     pub delivery_id: u64,
 }
 
-pub trait Message {
+pub trait Payload {
     fn msg_type(&self) -> &str;
     fn to_bytes(&self) -> Vec<u8>;
 }
@@ -35,8 +35,8 @@ pub enum Type {
 }
 
 pub trait Channel {
-    fn ack(&mut self, msg: &MQMessage);
-    fn sub(&mut self, f: Box<Fn(MQMessage)>);
-    fn publish(&mut self, routing_key: &str, payload: &Message);
+    fn ack(&mut self, msg: &Message);
+    fn sub(&mut self, f: Box<Fn(Message)>);
+    fn publish(&mut self, routing_key: &str, payload: &Payload);
 }
 

--- a/message_queue/src/channel.rs
+++ b/message_queue/src/channel.rs
@@ -15,6 +15,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use std;
+
+pub struct MQMessage {
+    pub routing_key: String,
+    pub msg_type: String,
+    pub payload: Vec<u8>,
+    pub delivery_id: u64,
+}
+
 pub trait Message {
     fn msg_type(&self) -> &str;
     fn to_bytes(&self) -> Vec<u8>;
@@ -26,8 +35,8 @@ pub enum Type {
 }
 
 pub trait Channel {
-    fn ack(&self, msg: &Message);
-    fn sub(&self, f: &Fn(&Message));
-    fn publish(&self, msg: &Message);
+    fn ack(&mut self, msg: &MQMessage);
+    fn sub(&mut self, f: Box<Fn(MQMessage)>);
+    fn publish(&mut self, routing_key: &str, payload: &Message);
 }
 

--- a/message_queue/src/lib.rs
+++ b/message_queue/src/lib.rs
@@ -1,0 +1,23 @@
+// CITA
+// Copyright 2016-2017 Cryptape Technologies LLC.
+
+// This program is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any
+// later version.
+
+// This program is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied
+// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::convert::Into;
+use std::sync::mpsc::Receiver;
+use std::sync::mpsc::Sender;
+
+mod channel;
+mod tracing_channel;

--- a/message_queue/src/lib.rs
+++ b/message_queue/src/lib.rs
@@ -19,5 +19,5 @@ use std::convert::Into;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 
-mod channel;
-mod tracing_channel;
+pub mod channel;
+//mod tracing_channel;

--- a/message_queue/src/tracing_channel.rs
+++ b/message_queue/src/tracing_channel.rs
@@ -1,0 +1,59 @@
+// CITA
+// Copyright 2016-2017 Cryptape Technologies LLC.
+
+// This program is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any
+// later version.
+
+// This program is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied
+// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::convert::Into;
+use std::sync::mpsc::Receiver;
+use std::sync::mpsc::Sender;
+use channel::Message;
+use channel::Channel;
+
+struct TracingMessage<'a> {
+    msg: &'a Message
+}
+
+impl<'a> Message for TracingMessage<'a> {
+    fn msg_type(&self) -> &str { "" }
+    fn to_bytes(&self) -> Vec<u8> { vec![] }
+}
+
+struct TracingChannel<'a> {
+    channel: &'a Channel,
+    name: &'a str,
+}
+
+impl<'a> TracingChannel<'a> {
+    fn new(channel: &'a Channel, name: &'a str) -> Self {
+        TracingChannel { channel, name }
+    }
+}
+
+impl<'a> Channel for TracingChannel<'a> {
+    fn ack(&self, msg: &Message) {
+        // end new span
+    }
+
+    fn sub(&self, f: &Fn(&Message)) {
+        // start new span
+        self.channel.sub(&|msg| {
+            f(&TracingMessage { msg: msg });
+        })
+    }
+
+    fn publish(&self, msg: &Message) {
+        // inject properties with new tracing ID
+    }
+}

--- a/pubsub_rabbitmq/Cargo.toml
+++ b/pubsub_rabbitmq/Cargo.toml
@@ -6,3 +6,6 @@ authors = ["Cryptape Technologies <contact@cryptape.com>"]
 [dependencies.amqp]
 version = "0.1"
 default-features = false
+
+[dependencies]
+message_queue = { path = "../message_queue" }

--- a/pubsub_rabbitmq/src/channel.rs
+++ b/pubsub_rabbitmq/src/channel.rs
@@ -1,0 +1,134 @@
+// CITA
+// Copyright 2016-2017 Cryptape Technologies LLC.
+
+// This program is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any
+// later version.
+
+// This program is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied
+// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std;
+use std::thread;
+use amqp::{protocol, Consumer, Table, Basic};
+use mq::channel::{Channel, Type, Message, MQMessage};
+use std::sync::mpsc::{Receiver, Sender, channel};
+
+pub struct MQChannel {
+    channel: amqp::Channel,
+    queue: String,
+}
+
+pub struct Handler {
+    f: Box<Fn(MQMessage)>
+}
+
+unsafe impl Send for Handler {}
+
+impl Consumer for Handler {
+    fn handle_delivery(
+        &mut self,
+        channel: &mut amqp::Channel,
+        deliver: protocol::basic::Deliver,
+        _: protocol::basic::BasicProperties,
+        body: Vec<u8>,
+    ) {
+        let msg = MQMessage {
+            delivery_id: deliver.delivery_tag,
+            payload: body,
+            msg_type: "".to_string(),
+            routing_key: deliver.routing_key,
+        };
+        (*self.f)(msg);
+    }
+}
+
+impl Channel for MQChannel {
+    fn sub(&mut self, f: Box<Fn(MQMessage)>) {
+        let callback = Handler { f };
+        self.channel
+            .basic_consume(
+                callback,
+                self.queue.clone(),
+                "".to_string(),
+                false,
+                false,
+                false,
+                false,
+                Table::new(),
+            )
+            .unwrap();
+        self.channel.start_consuming();
+        let _ = self.channel.close(200, "Bye");
+    }
+
+    fn ack(&mut self, msg: &MQMessage) {
+        self.channel.basic_ack(msg.delivery_id, false);
+    }
+
+    fn publish(&mut self, routing_key: &str, payload: &Message) {
+        self.channel.basic_publish(
+            "cita",
+            &routing_key,
+            false,
+            false,
+            protocol::basic::BasicProperties {
+                content_type: Some("text".to_string()),
+                ..Default::default()
+            },
+            payload.to_bytes(),
+        );
+    }
+}
+
+pub const AMQP_URL: &'static str = "AMQP_URL";
+
+pub fn new_channel(queue: &str, keys: Vec<String>, channel_type: Type) -> MQChannel {
+    let amqp_url = std::env::var(AMQP_URL).expect(format!("{} must be set", AMQP_URL).as_str());
+    let mut session = match amqp::Session::open_url(&amqp_url) {
+        Ok(session) => session,
+        Err(error) => panic!("failed to open url {} : {:?}", amqp_url, error),
+    };
+
+    let mut channel = session.open_channel(1).ok().expect("Can't open channel");
+    {
+        let channel = &mut channel;
+        let _ = channel.basic_prefetch(10);
+
+        let channel_type = match channel_type {
+            Type::Broadcast => "topic",
+            Type::Queue => "direct",
+        };
+        channel
+            .exchange_declare(
+                "cita",
+                channel_type,
+                false,
+                true,
+                false,
+                false,
+                false,
+                Table::new(),
+            )
+            .unwrap();
+
+        channel
+            .queue_declare(queue.clone(), false, true, false, false, false, Table::new())
+            .unwrap();
+
+        for key in keys {
+            channel
+                .queue_bind(queue.clone(), "cita", &key, false, Table::new())
+                .unwrap();
+        }
+    }
+    let queue = queue.to_string();
+    MQChannel { queue: queue, channel: channel }
+}

--- a/pubsub_rabbitmq/src/channel.rs
+++ b/pubsub_rabbitmq/src/channel.rs
@@ -132,3 +132,35 @@ pub fn new_channel(queue: &str, keys: Vec<String>, channel_type: Type) -> MQChan
     let queue = queue.to_string();
     MQChannel { queue: queue, channel: channel }
 }
+
+#[cfg(test)]
+mod tests {
+    use std;
+    use super::Channel;
+
+    struct A {
+        name: String
+    }
+
+    impl super::Payload for A {
+        fn msg_type(&self) -> &str {
+            "A"
+        }
+        fn to_bytes(&self) -> Vec<u8> {
+            self.name.to_string().into_bytes()
+        }
+    }
+
+    #[test]
+    fn test() {
+        if std::env::var(super::AMQP_URL).is_ok() {
+            let mut mq = super::new_channel("hehe", vec!["a".to_string()], super::Type::Broadcast);
+            let t = super::thread::spawn(move || {
+                let msg = A { name: "nihao".to_string() };
+                mq.publish("", &msg);
+                println!("val is {}", mq.queue);
+            });
+            t.join().unwrap();
+        }
+    }
+}

--- a/pubsub_rabbitmq/src/lib.rs
+++ b/pubsub_rabbitmq/src/lib.rs
@@ -15,11 +15,16 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#![feature(extern_prelude)]
 extern crate amqp;
+extern crate message_queue as mq;
+
 use amqp::{protocol, Basic, Channel, Consumer, Session, Table};
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 use std::thread;
+
+mod channel;
 
 pub struct Handler {
     tx: Sender<(String, Vec<u8>)>,


### PR DESCRIPTION
The current pubsub module does not have a proper abstraction,  hidden too many useful details, and expose a complex interface.

This PR try to refactoring pubsub with a proper abstraction, expose useful MQ methods like ack, topic-type. and also provide back compatible interface.

I'll also try to add a traceable MQ channel implementation for the further work preparation.