### PR TITLE
Add some functions and a struct for jsonrpc-types.

### DIFF
--- a/jsonrpc-types/src/rpctypes/basic/arbitrary_data.rs
+++ b/jsonrpc-types/src/rpctypes/basic/arbitrary_data.rs
@@ -71,8 +71,9 @@ impl<'de> Visitor<'de> for DataVisitor {
             let data = FromHex::from_hex(&value[2..]).map_err(|_| {
                 if value.len() > 12 {
                     E::custom(format!(
-                        "invalid hexadecimal string: [{}..{}]",
+                        "invalid hexadecimal string: [{}..(omit {})..{}]",
                         &value[..6],
+                        value.len() - 12,
                         &value[value.len() - 6..value.len()]
                     ))
                 } else {
@@ -83,8 +84,9 @@ impl<'de> Visitor<'de> for DataVisitor {
         } else {
             if value.len() > 12 {
                 Err(E::custom(format!(
-                    "invalid format: [{}..{}]",
+                    "invalid format: [{}..(omit {})..{}]",
                     &value[..6],
+                    value.len() - 12,
                     &value[value.len() - 6..value.len()]
                 )))
             } else {

--- a/jsonrpc-types/src/rpctypes/basic/fixed_data.rs
+++ b/jsonrpc-types/src/rpctypes/basic/fixed_data.rs
@@ -78,8 +78,9 @@ macro_rules! impl_for_fixed_type {
                     let data = $inner::from_str(&value[2..]).map_err(|_| {
                         if value.len() > 12 {
                             E::custom(format!(
-                                "invalid hexadecimal string: [{}..{}]",
+                                "invalid hexadecimal string: [{}..(omit {})..{}]",
                                 &value[..6],
+                                value.len() - 12,
                                 &value[value.len() - 6..value.len()]
                             ))
                         } else {
@@ -90,8 +91,9 @@ macro_rules! impl_for_fixed_type {
                 } else {
                     if value.len() > 12 {
                         Err(E::custom(format!(
-                            "invalid format: [{}..{}]",
+                            "invalid format: [{}..(omit {})..{}]",
                             &value[..6],
+                            value.len() - 12,
                             &value[value.len() - 6..value.len()]
                         )))
                     } else {

--- a/jsonrpc-types/src/rpctypes/basic/quantity.rs
+++ b/jsonrpc-types/src/rpctypes/basic/quantity.rs
@@ -68,8 +68,9 @@ impl<'de> Visitor<'de> for QuantityVisitor {
             let data = U256::from_str(&value[2..]).map_err(|_| {
                 if value.len() > 12 {
                     E::custom(format!(
-                        "invalid hexadecimal string: [{}..{}]",
+                        "invalid hexadecimal string: [{}..(omit {})..{}]",
                         &value[..6],
+                        value.len() - 12,
                         &value[value.len() - 6..value.len()]
                     ))
                 } else {
@@ -81,8 +82,9 @@ impl<'de> Visitor<'de> for QuantityVisitor {
             let data = U256::from_dec_str(&value[..]).map_err(|_| {
                 if value.len() > 12 {
                     E::custom(format!(
-                        "invalid decimal string: [{}..{}]",
+                        "invalid decimal string: [{}..(omit {})..{}]",
                         &value[..6],
+                        value.len() - 12,
                         &value[value.len() - 6..value.len()]
                     ))
                 } else {

--- a/jsonrpc-types/src/rpctypes/mod.rs
+++ b/jsonrpc-types/src/rpctypes/mod.rs
@@ -29,8 +29,11 @@ mod specs;
 mod transaction;
 mod tx_response;
 
+#[cfg(test)]
+mod tests;
+
 pub use self::basic::{
-    BlockTag, Boolean, Data, Data20, Data32, OneItemTupleTrick, Quantity, VariadicValue,
+    BlockTag, Boolean, Data, Data20, Data32, Integer, OneItemTupleTrick, Quantity, VariadicValue,
 };
 pub use self::exchange::{BlockParamsByHash, BlockParamsByNumber, CountOrCode, RpcBlock};
 pub use self::specs::{Id, Params, Version};
@@ -43,5 +46,25 @@ pub use self::log::Log;
 pub use self::meta_data::MetaData;
 pub use self::proof::{AuthorityRoundProof, Proof, TendermintProof};
 pub use self::receipt::Receipt;
-pub use self::transaction::{BlockTransaction, FullTransaction, RpcTransaction};
+pub use self::transaction::{BlockTransaction, FullTransaction, RpcTransaction, Transaction};
 pub use self::tx_response::TxResponse;
+
+use serde_json;
+
+macro_rules! impl_from_jsonstr_for {
+    ($type:ty) => {
+        impl $type {
+            pub fn from_jsonstr(s: &str) -> Result<Self, serde_json::Error> {
+                serde_json::from_str(s)
+            }
+        }
+    };
+    ($( $type:ident ),+) => {
+        $( impl_from_jsonstr_for!($type); )+
+    };
+    ($( $type:ident ),+ ,) => {
+        impl_from_jsonstr_for!($($type),+);
+    };
+}
+
+impl_from_jsonstr_for!(BlockTag, Boolean, Data, Data20, Data32, Quantity, Integer);

--- a/jsonrpc-types/src/rpctypes/tests.rs
+++ b/jsonrpc-types/src/rpctypes/tests.rs
@@ -1,0 +1,65 @@
+// CITA
+// Copyright 2016-2018 Cryptape Technologies LLC.
+
+// This program is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any
+// later version.
+
+// This program is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied
+// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use cita_types::{H160, H256, U256};
+
+use rpctypes::{BlockTag, Boolean, Data, Data20, Data32, Integer, Quantity};
+
+macro_rules! test_from_jsonstr {
+    ($type:tt, $jsonstr:expr, $expected_opt:expr) => {
+        let result = $type::from_jsonstr($jsonstr);
+        if let Some(expected) = $expected_opt {
+            assert_eq!(result.unwrap(), expected);
+        } else {
+            assert!(result.is_err());
+        }
+    };
+}
+
+#[test]
+fn from_jsonstr() {
+    test_from_jsonstr!(BlockTag, r#""latest""#, Some(BlockTag::Latest));
+    test_from_jsonstr!(BlockTag, r#""earliest""#, Some(BlockTag::Earliest));
+    test_from_jsonstr!(Boolean, r#"true"#, Some(Boolean::new(true)));
+    test_from_jsonstr!(Boolean, r#"false"#, Some(Boolean::new(false)));
+    test_from_jsonstr!(
+        Data,
+        r#""0xabcdef""#,
+        Some(Data::new(vec![0xab, 0xcd, 0xef]))
+    );
+    let auint = 11259375u64;
+    test_from_jsonstr!(
+        Data20,
+        format!(r#""{:#042x}""#, auint).as_ref(),
+        Some(Data20::new(H160::from(auint)))
+    );
+    test_from_jsonstr!(
+        Data32,
+        format!(r#""{:#066x}""#, auint).as_ref(),
+        Some(Data32::new(H256::from(auint)))
+    );
+    test_from_jsonstr!(
+        Integer,
+        format!(r#"{}"#, auint).as_ref(),
+        Some(Integer::new(auint))
+    );
+    test_from_jsonstr!(
+        Quantity,
+        format!(r#""{:#x}""#, auint).as_ref(),
+        Some(Quantity::new(U256::from(auint)))
+    );
+}


### PR DESCRIPTION
- Improve error messages: print length of omit chars in error messages.
- Add struct `Transaction`.
- Add cast functions between `Integer` and `u32` / `u16` / `u8` .
- Add `from_jsonstr` function for all basic jsonrpc types.