### PR TITLE
add db's name to the name of backup db

### DIFF
--- a/util/src/kvdb.rs
+++ b/util/src/kvdb.rs
@@ -766,7 +766,7 @@ impl Database {
 
         let mut backup_db = PathBuf::from(&self.path);
         backup_db.pop();
-        backup_db.push("backup_db");
+        backup_db.push(self.path.clone() + "_backup_db");
 
         let existed = match fs::rename(&self.path, &backup_db) {
             Ok(_) => true,


### PR DESCRIPTION
so as to restore chain's db and executor's db at the same time.
otherwise it may return error.