### PR TITLE
Remove a duplicated type.

### DIFF
--- a/cita-ed25519/src/lib.rs
+++ b/cita-ed25519/src/lib.rs
@@ -40,7 +40,6 @@ pub const HASH_BYTES_LEN: usize = 32;
 pub type PrivKey = H512;
 pub type PubKey = H256;
 pub type Message = H256;
-pub type Public = H256;
 
 pub use self::error::*;
 pub use self::keypair::*;

--- a/cita-secp256k1/src/lib.rs
+++ b/cita-secp256k1/src/lib.rs
@@ -33,7 +33,6 @@ extern crate util;
 pub type PrivKey = H256;
 pub type PubKey = H512;
 pub type Message = H256;
-pub type Public = H512;
 
 pub const ADDR_BYTES_LEN: usize = 20;
 pub const PUBKEY_BYTES_LEN: usize = 64;

--- a/cita-sm2/src/lib.rs
+++ b/cita-sm2/src/lib.rs
@@ -37,7 +37,6 @@ pub use self::signer::*;
 pub type PrivKey = H256;
 pub type PubKey = H512;
 pub type Message = H256;
-pub type Public = H256;
 
 pub const ADDR_BYTES_LEN: usize = 20;
 pub const PUBKEY_BYTES_LEN: usize = 64;

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Cryptape Technologies <contact@cryptape.com>"]
 
 [dependencies]
-log = "0.4"
+log = "=0.4.3"
 log4rs = "0.8"
 chan-signal = "0.3"
 chrono = "0.4"


### PR DESCRIPTION
`Public` is a duplicated type. We should use `PubKey` to replace it.

And, fix the CI.