### PR TITLE
Ignore #[allow(clippy)] for build.

### DIFF
--- a/util/src/build_info.rs
+++ b/util/src/build_info.rs
@@ -136,11 +136,13 @@ pub fn gen_build_info(out_dir: &str, dest_name: &str) {
         .replace("\n", "\\n");
     let code = format!(
         "
+        #[allow(unknown_lints)]
         #[allow(clippy)]
         pub fn get_build_info_str(short: bool) -> &'static str {{
            if short {{ \"{}\" }} else {{ \"{}\" }}
         }}
 
+        #[allow(unknown_lints)]
         #[allow(clippy)]
         pub fn get_build_info() -> (
            &'static str,          // ASCII Logo


### PR DESCRIPTION
- `#[allow(clippy)]` use for ignore `cargo clippy`.
- `#[allow(unknown_lints)]` use for ignore `#[allow(clippy)]` when `cargo build` with `RUSTFLAGS='-F warnings' `.