### PR TITLE
Use lapin-futures instead of rust-amqp for pubsub_rabbitmq (api compatibility).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "amq-protocol"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "amq-protocol-codegen 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "amq-protocol-types 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie-factory 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "amq-protocol-codegen"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "amq-protocol-types 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "handlebars 0.32.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "amq-protocol-types"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cookie-factory 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "amqp"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +456,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie-factory"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "core-foundation"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +586,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "crunchy"
@@ -843,7 +889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures"
-version = "0.1.21"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -851,7 +897,7 @@ name = "futures-cpupool"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -894,7 +940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "httpbis 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -940,7 +986,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -988,7 +1034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1012,7 +1058,7 @@ name = "hyper-tls"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1087,7 +1133,7 @@ name = "jsonrpc-core"
 version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1133,6 +1179,35 @@ dependencies = [
 name = "language-tags"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lapin-async"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "amq-protocol 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie-factory 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sasl 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lapin-futures"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "amq-protocol 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie-factory 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lapin-async 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1419,7 +1494,7 @@ dependencies = [
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1487,6 +1562,14 @@ version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nom"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1746,7 +1829,7 @@ dependencies = [
  "chrono 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "errno 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
@@ -1760,6 +1843,11 @@ name = "pubsub_rabbitmq"
 version = "0.1.0"
 dependencies = [
  "amqp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lapin-futures 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "logger 0.1.0",
+ "tokio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1864,7 +1952,7 @@ version = "0.12.0"
 source = "git+https://github.com/fede1024/rust-rdkafka.git?rev=84d4062#84d40623f38455dc7c3aa09539319a4d81bc57ab"
 dependencies = [
  "errno 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdkafka-sys 0.11.0-1 (git+https://github.com/fede1024/rust-rdkafka.git?rev=84d4062)",
@@ -1964,7 +2052,7 @@ name = "relay"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2041,6 +2129,14 @@ dependencies = [
 name = "safemem"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sasl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "schannel"
@@ -2183,7 +2279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "slab"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2380,19 +2476,22 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-current-thread 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-fs 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-fs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-udp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-uds 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2401,7 +2500,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2411,16 +2510,25 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-current-thread"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2428,15 +2536,15 @@ name = "tokio-executor"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-fs"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2447,7 +2555,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2456,7 +2564,7 @@ name = "tokio-proto"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2473,10 +2581,10 @@ name = "tokio-reactor"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2486,7 +2594,7 @@ name = "tokio-service"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2495,7 +2603,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2508,7 +2616,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2520,16 +2628,18 @@ name = "tokio-timer"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-timer"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2538,7 +2648,7 @@ name = "tokio-tls"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2549,7 +2659,7 @@ name = "tokio-tls-api"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "tls-api 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2561,7 +2671,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2575,7 +2685,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2583,6 +2693,22 @@ dependencies = [
  "mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-uds"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2840,7 +2966,7 @@ name = "want"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2854,7 +2980,7 @@ dependencies = [
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2881,7 +3007,7 @@ dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2991,6 +3117,9 @@ dependencies = [
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum aho-corasick 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f0ba20154ea1f47ce2793322f049c5646cc6d0fa9759d5f333f286e507bf8080"
 "checksum amq-proto 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "66d79639b71f74c7006c12683cc2ff221615a51a741688fa7798ccd080dc54d3"
+"checksum amq-protocol 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)" = "21cab4bad7494c3feebb7eae22345b80164eeebd3da02014f0ce0c4e1db8ff7f"
+"checksum amq-protocol-codegen 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5090d3941f35e4c8aa296f2f8ed499aaf01583409600287a5437e4708e65ea72"
+"checksum amq-protocol-types 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4793f877f96d4f1564664a3f13f8c4680365408a142498f998ac834ebfc40cb0"
 "checksum amqp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e1a60ccc700b6a79480c8ee0140f231db4a23b7b6ff18581f84f7091f6bbcce4"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
@@ -3025,6 +3154,7 @@ dependencies = [
 "checksum clippy 0.0.175 (registry+https://github.com/rust-lang/crates.io-index)" = "2dae056aaec8acd5fc26722234cc9fa03b969a860d9aef0da6c5e5c996ce66ae"
 "checksum clippy_lints 0.0.175 (registry+https://github.com/rust-lang/crates.io-index)" = "d04f24bc10870e19880865d8f206168993bfc6df9cc7335c0692cad98378a4b6"
 "checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
+"checksum cookie-factory 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "98a479f8099cc5ac64915a3dd76c87be27f929ba406ad705aacb13f19b791207"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
 "checksum criterion 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b027da737a814e7ffcfdbaf1c0509fbaea4c6df5f2e116c820ecf515ad39ac9b"
@@ -3037,6 +3167,7 @@ dependencies = [
 "checksum crossbeam-epoch 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2af0e75710d6181e234c8ecc79f14a97907850a541b13b0be1dd10992f2e4620"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
+"checksum crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "677d453a17e8bd2b913fa38e8b9cf04bcdbb5be790aa294f2389661d72036015"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum csv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71903184af9960c555e7f3b32ff17390d20ecaaf17d4f18c4a0993f2df8a49e3"
 "checksum csv-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4dd8e6d86f7ba48b4276ef1317edc8cc36167546d8972feb4a2b5fec0b374105"
@@ -3066,7 +3197,7 @@ dependencies = [
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
+"checksum futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "0c84b40c7e2de99ffd70602db314a7a8c26b2b3d830e6f7f7a142a8860ab3ca4"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "b900c08c1939860ce8b54dc6a89e26e00c04c380fd0e09796799bd7f12861e05"
@@ -3092,6 +3223,8 @@ dependencies = [
 "checksum jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ddf83704f4e79979a424d1082dd2c1e52683058056c9280efa19ac5f6bc9033c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
+"checksum lapin-async 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc4b5a3e92f803fea39a5d075a4558424dd7b12b93929f447bb74064febbfaa2"
+"checksum lapin-futures 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1818d0899f92fdbb48ef7f1a76cb64baa128534c0e7379a86f8656bb8fac30f6"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
@@ -3128,6 +3261,7 @@ dependencies = [
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
+"checksum nom 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "898696750eb5c3ce5eb5afbfbe46e7f7c4e1936e19d3e97be4b7937da7b6d114"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
 "checksum num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
@@ -3185,6 +3319,7 @@ dependencies = [
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
+"checksum sasl 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4dbda5436dcd059da44fbf84b87a7164c5e3cad354efd0630c1f2be3c51c8859"
 "checksum schannel 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "dc1fabf2a7b6483a141426e1afd09ad543520a77ac49bd03c286e7696ccfd77f"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
@@ -3203,7 +3338,7 @@ dependencies = [
 "checksum siphasher 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "833011ca526bd88f16778d32c699d325a9ad302fa06381cd66f7be63351d3f6d"
 "checksum skeptic 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24ebf8a06f5f8bae61ae5bbc7af7aac4ef6907ae975130faba1199e5fe82256a"
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
-"checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
+"checksum slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"
 "checksum smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8cbcd6df1e117c2210e13ab5109635ad68a929fcbb8964dc965b76cb5ee013"
 "checksum smallvec 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "211a489e65e94b103926d2054ae515a1cdb5d515ea0ef414fee23b7e043ce748"
 "checksum sodiumoxide 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71c0682b4406fa25d621b19d2e70b5f6c8627e39b4b7ce0e24b2ef05d0fbe1ca"
@@ -3228,11 +3363,12 @@ dependencies = [
 "checksum tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e9175261fbdb60781fcd388a4d6cc7e14764a2b629a7ad94abb439aed223a44f"
 "checksum tls-api 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "b433ee8bde283064ac414932e5c8d0ce20f9820b344a09398538ec240373e8c9"
 "checksum tls-api-stub 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "a7029e7c7ebdfc065c10fe4a065f52837fd0907551f7b3565d406c119b46c42a"
-"checksum tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8ee337e5f4e501fc32966fec6fe0ca0cc1c237b0b1b14a335f8bfe3c5f06e286"
+"checksum tokio 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "fbb6a6e9db2702097bfdfddcb09841211ad423b86c75b5ddaca1d62842ac492c"
 "checksum tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "881e9645b81c2ce95fcb799ded2c29ffb9f25ef5bef909089a420e5961dd8ccb"
 "checksum tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "aeeffbbb94209023feaef3c196a41cbcdafa06b4a6f893f68779bb5e53796f71"
+"checksum tokio-current-thread 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fdfb899688ac16f618076bd09215edbfda0fd5dfecb375b6942636cb31fa8a7"
 "checksum tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8cac2a7883ff3567e9d66bb09100d09b33d90311feca0206c7ca034bc0c55113"
-"checksum tokio-fs 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fc42bae2f6e33865b99069d95bcddfc85c9f0849b4e7e7399eeee71956ef34d7"
+"checksum tokio-fs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b5cbe4ca6e71cb0b62a66e4e6f53a8c06a6eefe46cc5f665ad6f274c9906f135"
 "checksum tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a5c9635ee806f26d302b8baa1e145689a280d8f5aa8d0552e7344808da54cc21"
 "checksum tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fbb47ae81353c63c487030659494b295f6cb6576242f907f203473b191b0389"
 "checksum tokio-reactor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e00ec63bbec2c97ce1178cb0587b2c438b2f6b09d3ee54a33c45a9cf0d530810"
@@ -3240,11 +3376,12 @@ dependencies = [
 "checksum tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec9b094851aadd2caf83ba3ad8e8c4ce65a42104f7b94d9e6550023f0407853f"
 "checksum tokio-threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c3873a6d8d0b636e024e77b9a82eaab6739578a06189ecd0e731c7308fbc5d"
 "checksum tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6131e780037787ff1b3f8aad9da83bca02438b72277850dd6ad0d455e0e20efc"
-"checksum tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "028b94314065b90f026a21826cffd62a4e40a92cda3e5c069cc7b02e5945f5e9"
+"checksum tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d03fa701f9578a01b7014f106b47f0a363b4727a7f3f75d666e312ab7acbbf1c"
 "checksum tokio-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "772f4b04e560117fe3b0a53e490c16ddc8ba6ec437015d91fa385564996ed913"
 "checksum tokio-tls-api 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "e00c40dfac88e87b728026c72426a0e2d4319fa8386eae9003093a3e00aee83e"
 "checksum tokio-udp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "43eb534af6e8f37d43ab1b612660df14755c42bd003c5f8d2475ee78cc4600c0"
 "checksum tokio-uds 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "65ae5d255ce739e8537221ed2942e0445f4b3b813daebac1c0050ddaaa3587f9"
+"checksum tokio-uds 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "424c1ed15a0132251813ccea50640b224c809d6ceafb88154c1a8775873a0e89"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
 "checksum toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a0263c6c02c4db6c8f7681f9fd35e90de799ebd4cfdeab77a38f4ff6b3d8c0d9"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,7 @@ dependencies = [
 name = "pubsub_rabbitmq"
 version = "0.1.0"
 dependencies = [
+ "amq-protocol 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "amqp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "lapin-futures 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -12,5 +12,6 @@ pubsub_kafka = { path = "../pubsub_kafka", optional = true }
 [features]
 default = []
 rabbitmq = ["pubsub_rabbitmq"]
+rabbitmq-rust-amqp = ["rabbitmq", "pubsub_rabbitmq/rust-amqp"]
 zeromq = ["pubsub_zeromq"]
 kafka = ["pubsub_kafka"]

--- a/pubsub_rabbitmq/Cargo.toml
+++ b/pubsub_rabbitmq/Cargo.toml
@@ -3,6 +3,13 @@ name = "pubsub_rabbitmq"
 version = "0.1.0"
 authors = ["Cryptape Technologies <contact@cryptape.com>"]
 
+[dependencies]
+lapin-futures = "0.13"
+tokio = "=0.1.8"
+futures = "0.1.24"
+logger = { path = "../logger" }
+tokio-io = "0.1"
+
 [dependencies.amqp]
 version = "0.1"
 default-features = false

--- a/pubsub_rabbitmq/Cargo.toml
+++ b/pubsub_rabbitmq/Cargo.toml
@@ -4,12 +4,14 @@ version = "0.1.0"
 authors = ["Cryptape Technologies <contact@cryptape.com>"]
 
 [dependencies]
+amqp = { version = "0.1", default-features = false }
 lapin-futures = "0.13"
+amq-protocol = "0.21"
 tokio = "=0.1.8"
 futures = "0.1.24"
 logger = { path = "../logger" }
 tokio-io = "0.1"
 
-[dependencies.amqp]
-version = "0.1"
-default-features = false
+[features]
+default = []
+rust-amqp = []

--- a/pubsub_rabbitmq/src/lapin_amqp.rs
+++ b/pubsub_rabbitmq/src/lapin_amqp.rs
@@ -1,0 +1,204 @@
+use futures::future::Future;
+use futures::stream;
+use futures::sync::mpsc;
+use futures::Stream;
+use lapin::channel::{
+    BasicConsumeOptions, BasicProperties, BasicPublishOptions, ExchangeDeclareOptions,
+    QueueBindOptions, QueueDeclareOptions, QueuePurgeOptions,
+};
+use lapin::client::{Client, ConnectionOptions};
+use lapin::message::Delivery;
+use lapin::types::FieldTable;
+use std::io;
+use std::io::{Error, ErrorKind};
+use std::net::SocketAddr;
+use std::sync::mpsc as std_mpsc;
+use std::thread;
+use tokio;
+use tokio::net::TcpStream;
+use tokio::runtime::Runtime;
+use tokio_io::{AsyncRead, AsyncWrite};
+
+pub type Payload = (String, Vec<u8>);
+
+pub const EXCHANGE: &str = "cita";
+pub const EXCHANGE_TYPE: &str = "topic";
+
+fn amqp_connect(
+    addr: SocketAddr,
+    name: &'static str,
+    keys: Vec<String>,
+    publisher_rx: mpsc::Receiver<Payload>,
+    consumer_tx: std_mpsc::Sender<Payload>,
+) -> impl Future<Item = (), Error = io::Error> + Send + 'static {
+    TcpStream::connect(&addr)
+        .and_then(|stream| {
+            // connect() returns a future of an AMQP Client
+            // that resolves once the handshake is done
+            Client::connect(stream, ConnectionOptions::default())
+        })
+        .and_then(move |(client, heartbeat)| {
+            tokio::spawn(heartbeat.map_err(|_| ()));
+            // create_channel returns a future that is resolved
+            // once the channel is successfully created
+            let publisher = publisher(&client, name, publisher_rx);
+            let consumer = consumer(&client, name, keys, consumer_tx);
+            publisher
+                .select2(consumer)
+                .map(|_| ())
+                .map_err(|_| Error::new(ErrorKind::Other, "channel closed!"))
+        })
+}
+
+fn publisher<T>(
+    client: &Client<T>,
+    name: &'static str,
+    publisher_rx: mpsc::Receiver<Payload>,
+) -> impl Future<Item = (), Error = io::Error> + Send + 'static
+where
+    T: AsyncRead + AsyncWrite,
+    T: Send + Sync,
+    T: 'static,
+{
+    client.create_channel().and_then(move |channel| {
+        channel
+            .queue_declare(name, QueueDeclareOptions::default(), FieldTable::new())
+            .and_then(move |_| {
+                debug!("publisher queue declared");
+                channel
+                    .queue_purge(name, QueuePurgeOptions::default())
+                    .and_then(move |_| {
+                        debug!("publisher queue purged");
+                        publisher_rx
+                            .for_each(move |(routing_key, msg): (String, Vec<u8>)| {
+                                tokio::spawn(
+                                    channel
+                                        .basic_publish(
+                                            EXCHANGE,
+                                            &routing_key,
+                                            msg,
+                                            BasicPublishOptions::default(),
+                                            BasicProperties::default(),
+                                        )
+                                        .map(|_| ())
+                                        .map_err(|_| ()),
+                                )
+                            })
+                            .map_err(|_| Error::new(ErrorKind::Other, "channel closed!"))
+                    })
+            })
+    })
+}
+
+fn consumer<T>(
+    client: &Client<T>,
+    name: &'static str,
+    keys: Vec<String>,
+    consumer_tx: std_mpsc::Sender<Payload>,
+) -> impl Future<Item = (), Error = io::Error> + Send + 'static
+where
+    T: AsyncRead + AsyncWrite,
+    T: Send + Sync,
+    T: 'static,
+{
+    let keys = stream::iter_ok::<_, ()>(keys);
+    client.create_channel().and_then(move |channel| {
+        let id = channel.id;
+        debug!("created channel with id: {}", id);
+
+        let ch1 = channel.clone();
+        let ch2 = channel.clone();
+
+        channel
+            .exchange_declare(
+                EXCHANGE,
+                EXCHANGE_TYPE,
+                ExchangeDeclareOptions::default(),
+                FieldTable::new(),
+            )
+            .and_then(move |_| {
+                channel
+                    .queue_declare(name, QueueDeclareOptions::default(), FieldTable::new())
+                    .and_then(move |queue| {
+                        debug!("channel {} declared queue {}", id, name);
+
+                        keys.for_each(move |key| {
+                            channel
+                                .queue_bind(
+                                    name,
+                                    EXCHANGE,
+                                    &key,
+                                    QueueBindOptions::default(),
+                                    FieldTable::new(),
+                                )
+                                .map(|_| ())
+                                .map_err(|_| ())
+                        }).map_err(|_| Error::new(ErrorKind::Other, "queue_bind error!"))
+                            .map(|_| queue)
+                    })
+                    .and_then(move |queue| {
+                        ch1.basic_consume(
+                            &queue,
+                            name,
+                            BasicConsumeOptions::default(),
+                            FieldTable::new(),
+                        )
+                    })
+            })
+            .and_then(|stream| {
+                stream.for_each(move |message| {
+                    let Delivery {
+                        delivery_tag,
+                        routing_key,
+                        data,
+                        ..
+                    } = message;
+                    let ret = consumer_tx.send((routing_key, data));
+                    if ret.is_err() {
+                        error!("amqp message send error {:?}", ret);
+                    }
+                    ch2.basic_ack(delivery_tag, false)
+                })
+            })
+    })
+}
+
+pub fn start_amqp(
+    addr: SocketAddr,
+    name: &'static str,
+    keys: Vec<String>,
+) -> (mpsc::Sender<Payload>, std_mpsc::Receiver<Payload>) {
+    let (publisher_tx, publisher_rx) = mpsc::channel(65535);
+    let (consumer_tx, consumer_rx) = std_mpsc::channel();
+
+    thread::spawn(move || {
+        Runtime::new().unwrap().block_on_all(amqp_connect(
+            addr,
+            name,
+            keys,
+            publisher_rx,
+            consumer_tx,
+        ))
+    });
+    (publisher_tx, consumer_rx)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    #[ignore]
+    fn basics() {
+        let addr = "127.0.0.1:5672".parse().unwrap();
+
+        let (mut tx, rx) = start_amqp(
+            addr,
+            "network",
+            vec!["chain.newtx".to_string(), "chain.newblk".to_string()],
+        );
+
+        tx.try_send(("chain.newtx".to_string(), vec![123])).unwrap();
+
+        assert_eq!(rx.recv().unwrap(), ("chain.newtx".to_string(), vec![123]));
+    }
+}

--- a/pubsub_rabbitmq/src/lapin_amqp.rs
+++ b/pubsub_rabbitmq/src/lapin_amqp.rs
@@ -1,7 +1,30 @@
+// CITA
+// Copyright 2016-2018 Cryptape Technologies LLC.
+
+// This program is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any
+// later version.
+
+// This program is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied
+// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::io::{self, Error, ErrorKind};
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::str::FromStr;
+use std::sync::mpsc as std_mpsc;
+use std::thread;
+
+use amq_protocol::uri::AMQPUri;
 use futures::future::Future;
-use futures::stream;
 use futures::sync::mpsc;
-use futures::Stream;
+use futures::{stream, Stream};
 use lapin::channel::{
     BasicConsumeOptions, BasicProperties, BasicPublishOptions, ExchangeDeclareOptions,
     QueueBindOptions, QueueDeclareOptions, QueuePurgeOptions,
@@ -9,29 +32,22 @@ use lapin::channel::{
 use lapin::client::{Client, ConnectionOptions};
 use lapin::message::Delivery;
 use lapin::types::FieldTable;
-use std::io;
-use std::io::{Error, ErrorKind};
-use std::net::SocketAddr;
-use std::sync::mpsc as std_mpsc;
-use std::thread;
 use tokio;
 use tokio::net::TcpStream;
 use tokio::runtime::Runtime;
 use tokio_io::{AsyncRead, AsyncWrite};
 
-pub type Payload = (String, Vec<u8>);
-
-pub const EXCHANGE: &str = "cita";
-pub const EXCHANGE_TYPE: &str = "topic";
+use super::{Payload, AMQP_URL, EXCHANGE, EXCHANGE_TYPE};
 
 fn connect_consumer(
     addr: SocketAddr,
-    name: &'static str,
+    conn_opts: ConnectionOptions,
+    name: String,
     keys: Vec<String>,
     consumer_tx: std_mpsc::Sender<Payload>,
 ) -> impl Future<Item = (), Error = io::Error> + Send + 'static {
     TcpStream::connect(&addr)
-        .and_then(|stream| Client::connect(stream, ConnectionOptions::default()))
+        .and_then(|stream| Client::connect(stream, conn_opts))
         .and_then(move |(client, heartbeat)| {
             tokio::spawn(heartbeat.map_err(|_| ()));
             consumer(&client, name, keys, consumer_tx)
@@ -40,11 +56,12 @@ fn connect_consumer(
 
 fn connect_publisher(
     addr: SocketAddr,
-    name: &'static str,
+    conn_opts: ConnectionOptions,
+    name: String,
     publisher_rx: mpsc::Receiver<Payload>,
 ) -> impl Future<Item = (), Error = io::Error> + Send + 'static {
     TcpStream::connect(&addr)
-        .and_then(|stream| Client::connect(stream, ConnectionOptions::default()))
+        .and_then(|stream| Client::connect(stream, conn_opts))
         .and_then(move |(client, heartbeat)| {
             tokio::spawn(heartbeat.map_err(|_| ()));
             publisher(&client, name, publisher_rx)
@@ -53,7 +70,7 @@ fn connect_publisher(
 
 fn publisher<T>(
     client: &Client<T>,
-    name: &'static str,
+    name: String,
     publisher_rx: mpsc::Receiver<Payload>,
 ) -> impl Future<Item = (), Error = io::Error> + Send + 'static
 where
@@ -63,15 +80,15 @@ where
 {
     client.create_channel().and_then(move |channel| {
         channel
-            .queue_declare(name, QueueDeclareOptions::default(), FieldTable::new())
+            .queue_declare(&name, QueueDeclareOptions::default(), FieldTable::new())
             .and_then(move |_| {
                 debug!("publisher queue declared");
                 channel
-                    .queue_purge(name, QueuePurgeOptions::default())
+                    .queue_purge(&name, QueuePurgeOptions::default())
                     .and_then(move |_| {
                         debug!("publisher queue purged");
                         publisher_rx
-                            .for_each(move |(routing_key, msg): (String, Vec<u8>)| {
+                            .for_each(move |(routing_key, msg): Payload| {
                                 tokio::spawn(
                                     channel
                                         .basic_publish(
@@ -93,7 +110,7 @@ where
 
 fn consumer<T>(
     client: &Client<T>,
-    name: &'static str,
+    name: String,
     keys: Vec<String>,
     consumer_tx: std_mpsc::Sender<Payload>,
 ) -> impl Future<Item = (), Error = io::Error> + Send + 'static
@@ -110,6 +127,8 @@ where
         let ch1 = channel.clone();
         let ch2 = channel.clone();
 
+        let name_clone = name.clone();
+
         channel
             .exchange_declare(
                 EXCHANGE,
@@ -119,14 +138,14 @@ where
             )
             .and_then(move |_| {
                 channel
-                    .queue_declare(name, QueueDeclareOptions::default(), FieldTable::new())
+                    .queue_declare(&name, QueueDeclareOptions::default(), FieldTable::new())
                     .and_then(move |queue| {
-                        debug!("channel {} declared queue {}", id, name);
+                        debug!("channel {} declared queue {}", id, name_clone);
 
                         keys.for_each(move |key| {
                             channel
                                 .queue_bind(
-                                    name,
+                                    &name_clone,
                                     EXCHANGE,
                                     &key,
                                     QueueBindOptions::default(),
@@ -140,7 +159,7 @@ where
                     .and_then(move |queue| {
                         ch1.basic_consume(
                             &queue,
-                            name,
+                            &name,
                             BasicConsumeOptions::default(),
                             FieldTable::new(),
                         )
@@ -164,45 +183,65 @@ where
     })
 }
 
-pub fn start_amqp(
-    addr: SocketAddr,
-    name: &'static str,
+pub fn start_rabbitmq(
+    name: &str,
     keys: Vec<String>,
-) -> (mpsc::Sender<Payload>, std_mpsc::Receiver<Payload>) {
+    tx: std_mpsc::Sender<Payload>,
+    rx: std_mpsc::Receiver<Payload>,
+) {
+    debug!("Starting rabbitmq via lapin-amqp ...");
+
+    let amqp_url = ::std::env::var(AMQP_URL).expect(format!("{} must be set", AMQP_URL).as_str());
+
+    let uri = AMQPUri::from_str(&amqp_url)
+        .unwrap_or_else(|err| panic!("Failed to parse AMQP Url {}: {}", amqp_url, err));
+
+    let addr = format!("{}:{}", uri.authority.host, uri.authority.port)
+        .as_str()
+        .to_socket_addrs()
+        .map_err(|err| panic!("Failed to parse or resolve addr from {}: {}", amqp_url, err))
+        .ok()
+        .and_then(|mut x| x.next())
+        .unwrap_or_else(|| panic!("Failed to parse or resolve addr from {}", amqp_url));
+
+    let conn_opts = ConnectionOptions::from_uri(uri);
+
     let (publisher_tx, publisher_rx) = mpsc::channel(65535);
-    let (consumer_tx, consumer_rx) = std_mpsc::channel();
 
-    thread::spawn(move || {
-        Runtime::new()
-            .unwrap()
-            .block_on_all(connect_publisher(addr, name, publisher_rx))
-    });
+    // Transfer data between different channels for api compatibility
+    let _ = thread::Builder::new()
+        .name("transfer".to_string())
+        .spawn(move || {
+            loop {
+                if let Ok(data) = rx.recv() {
+                    let _ = publisher_tx.clone().try_send(data);
+                } else {
+                    break;
+                }
+            }
+            ::std::process::exit(0);
+        });
 
-    thread::spawn(move || {
-        Runtime::new()
-            .unwrap()
-            .block_on_all(connect_consumer(addr, name, keys, consumer_tx))
-    });
+    {
+        let name = name.to_owned();
+        let conn_opts = conn_opts.clone();
+        thread::spawn(move || {
+            Runtime::new().unwrap().block_on_all(connect_publisher(
+                addr,
+                conn_opts,
+                name,
+                publisher_rx,
+            ))
+        });
+    }
 
-    (publisher_tx, consumer_rx)
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    #[test]
-    // #[ignore]
-    fn basics() {
-        let addr = "127.0.0.1:5672".parse().unwrap();
-
-        let (mut tx, rx) = start_amqp(
-            addr,
-            "network",
-            vec!["chain.newtx".to_string(), "chain.newblk".to_string()],
-        );
-
-        tx.try_send(("chain.newtx".to_string(), vec![123])).unwrap();
-
-        assert_eq!(rx.recv().unwrap(), ("chain.newtx".to_string(), vec![123]));
+    {
+        let name = name.to_owned();
+        let conn_opts = conn_opts.clone();
+        thread::spawn(move || {
+            Runtime::new()
+                .unwrap()
+                .block_on_all(connect_consumer(addr, conn_opts, name, keys, tx))
+        });
     }
 }

--- a/pubsub_rabbitmq/src/lib.rs
+++ b/pubsub_rabbitmq/src/lib.rs
@@ -17,6 +17,7 @@
 
 extern crate amqp;
 
+extern crate amq_protocol;
 extern crate futures;
 extern crate lapin_futures as lapin;
 extern crate tokio;
@@ -24,149 +25,18 @@ extern crate tokio_io;
 #[macro_use]
 extern crate logger;
 
-mod lapin_amqp;
+pub mod lapin_amqp;
+pub mod rust_amqp;
 
-use amqp::{protocol, Basic, Channel, Consumer, Session, Table};
-use std::process;
-use std::sync::mpsc::Receiver;
-use std::sync::mpsc::Sender;
-use std::thread;
+pub type Payload = (String, Vec<u8>);
 
-pub struct Handler {
-    tx: Sender<(String, Vec<u8>)>,
-}
-
-impl Handler {
-    pub fn new(tx: Sender<(String, Vec<u8>)>) -> Self {
-        Handler { tx: tx }
-    }
-}
-
-impl Consumer for Handler {
-    fn handle_delivery(
-        &mut self,
-        channel: &mut Channel,
-        deliver: protocol::basic::Deliver,
-        _: protocol::basic::BasicProperties,
-        body: Vec<u8>,
-    ) {
-        let _ = self.tx.send((deliver.routing_key, body));
-        let _ = channel.basic_ack(deliver.delivery_tag, false);
-    }
-}
+pub const EXCHANGE: &str = "cita";
+pub const EXCHANGE_TYPE: &str = "topic";
 
 pub const AMQP_URL: &'static str = "AMQP_URL";
 
-pub fn start_rabbitmq(
-    name: &str,
-    keys: Vec<String>,
-    tx: Sender<(String, Vec<u8>)>,
-    rx: Receiver<(String, Vec<u8>)>,
-) {
-    let amqp_url = std::env::var(AMQP_URL).expect(format!("{} must be set", AMQP_URL).as_str());
-    let mut session = match Session::open_url(&amqp_url) {
-        Ok(session) => session,
-        Err(error) => panic!("failed to open url {} : {:?}", amqp_url, error),
-    };
+#[cfg(feature = "rust-amqp")]
+pub use rust_amqp::start_rabbitmq;
 
-    let mut channel = session.open_channel(1).ok().expect("Can't open channel");
-    let _ = channel.basic_prefetch(10);
-    channel
-        .exchange_declare(
-            "cita",
-            "topic",
-            false,
-            true,
-            false,
-            false,
-            false,
-            Table::new(),
-        )
-        .unwrap();
-
-    //queue: &str, passive: bool, durable: bool, exclusive: bool, auto_delete: bool, nowait: bool, arguments: Table
-    channel
-        .queue_declare(name.clone(), false, true, false, false, false, Table::new())
-        .unwrap();
-
-    for key in keys {
-        channel
-            .queue_bind(name.clone(), "cita", &key, false, Table::new())
-            .unwrap();
-    }
-    let callback = Handler::new(tx);
-    //queue: &str, consumer_tag: &str, no_local: bool, no_ack: bool, exclusive: bool, nowait: bool, arguments: Table
-    channel
-        .basic_consume(
-            callback,
-            name.clone(),
-            "",
-            false,
-            false,
-            false,
-            false,
-            Table::new(),
-        )
-        .unwrap();
-
-    // thread recv msg from mq
-    let _ = thread::Builder::new()
-        .name("subscriber".to_string())
-        .spawn(move || {
-            channel.start_consuming();
-            let _ = channel.close(200, "Bye");
-            // Rabbitmq connection closed, amqp didn't handle this failure
-            // So we must exit the process, wait for restart
-            process::exit(0);
-        });
-
-    let mut session = match Session::open_url(&amqp_url) {
-        Ok(session) => session,
-        Err(error) => panic!("failed to open url {} : {:?}", amqp_url, error),
-    };
-    let mut channel = session.open_channel(1).ok().expect("Can't open channel");
-    let _ = channel.basic_prefetch(10);
-    channel
-        .exchange_declare(
-            "cita",
-            "topic",
-            false,
-            true,
-            false,
-            false,
-            false,
-            Table::new(),
-        )
-        .unwrap();
-
-    // thread send msg to mq
-    let _ = thread::Builder::new()
-        .name("publisher".to_string())
-        .spawn(move || {
-            loop {
-                let ret = rx.recv();
-                if ret.is_err() {
-                    break;
-                }
-                let (routing_key, msg) = ret.unwrap();
-                let ret = channel.basic_publish(
-                    "cita",
-                    &routing_key,
-                    false,
-                    false,
-                    protocol::basic::BasicProperties {
-                        content_type: Some("text".to_string()),
-                        ..Default::default()
-                    },
-                    msg,
-                );
-                if ret.is_err() {
-                    break;
-                }
-            }
-            let _ = channel.close(200, "Bye");
-            // Rabbitmq connection closed, amqp didn't handle this failure
-            // So we must exit the process, wait for restart
-            process::exit(0);
-        });
-}
+#[cfg(not(feature = "rust-amqp"))]
+pub use lapin_amqp::start_rabbitmq;

--- a/pubsub_rabbitmq/src/lib.rs
+++ b/pubsub_rabbitmq/src/lib.rs
@@ -16,6 +16,16 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 extern crate amqp;
+
+extern crate futures;
+extern crate lapin_futures as lapin;
+extern crate tokio;
+extern crate tokio_io;
+#[macro_use]
+extern crate logger;
+
+mod lapin_amqp;
+
 use amqp::{protocol, Basic, Channel, Consumer, Session, Table};
 use std::process;
 use std::sync::mpsc::Receiver;

--- a/pubsub_rabbitmq/src/rust_amqp.rs
+++ b/pubsub_rabbitmq/src/rust_amqp.rs
@@ -1,0 +1,145 @@
+// CITA
+// Copyright 2016-2018 Cryptape Technologies LLC.
+
+// This program is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any
+// later version.
+
+// This program is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied
+// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+use amqp::{protocol, Basic, Channel, Consumer, Session, Table};
+use std::process;
+use std::sync::mpsc::Receiver;
+use std::sync::mpsc::Sender;
+use std::thread;
+
+use super::{Payload, AMQP_URL, EXCHANGE, EXCHANGE_TYPE};
+
+pub struct Handler {
+    tx: Sender<Payload>,
+}
+
+impl Handler {
+    pub fn new(tx: Sender<Payload>) -> Self {
+        Handler { tx: tx }
+    }
+}
+
+impl Consumer for Handler {
+    fn handle_delivery(
+        &mut self,
+        channel: &mut Channel,
+        deliver: protocol::basic::Deliver,
+        _: protocol::basic::BasicProperties,
+        body: Vec<u8>,
+    ) {
+        let _ = self.tx.send((deliver.routing_key, body));
+        let _ = channel.basic_ack(deliver.delivery_tag, false);
+    }
+}
+
+pub fn init_channel(amqp_url: &str) -> Channel {
+    let mut session = match Session::open_url(amqp_url) {
+        Ok(session) => session,
+        Err(error) => panic!("Failed to open url {} : {:?}", amqp_url, error),
+    };
+    let mut channel = session.open_channel(1).ok().expect("Can't open channel");
+    let _ = channel.basic_prefetch(10);
+    channel
+        .exchange_declare(
+            EXCHANGE,
+            EXCHANGE_TYPE,
+            false,
+            true,
+            false,
+            false,
+            false,
+            Table::new(),
+        )
+        .unwrap();
+    channel
+}
+
+pub fn start_rabbitmq(name: &str, keys: Vec<String>, tx: Sender<Payload>, rx: Receiver<Payload>) {
+    debug!("Starting rabbitmq via rust-amqp ...");
+
+    let amqp_url = ::std::env::var(AMQP_URL).expect(format!("{} must be set", AMQP_URL).as_str());
+    let mut channel = init_channel(&amqp_url);
+
+    //queue: &str, passive: bool, durable: bool, exclusive: bool, auto_delete: bool, nowait: bool, arguments: Table
+    channel
+        .queue_declare(name.clone(), false, true, false, false, false, Table::new())
+        .unwrap();
+
+    for key in keys {
+        channel
+            .queue_bind(name.clone(), EXCHANGE, &key, false, Table::new())
+            .unwrap();
+    }
+    let callback = Handler::new(tx);
+    //queue: &str, consumer_tag: &str, no_local: bool, no_ack: bool, exclusive: bool, nowait: bool, arguments: Table
+    channel
+        .basic_consume(
+            callback,
+            name.clone(),
+            "",
+            false,
+            false,
+            false,
+            false,
+            Table::new(),
+        )
+        .unwrap();
+
+    // thread recv msg from mq
+    let _ = thread::Builder::new()
+        .name("subscriber".to_string())
+        .spawn(move || {
+            channel.start_consuming();
+            let _ = channel.close(200, "Bye");
+            // Rabbitmq connection closed, amqp didn't handle this failure
+            // So we must exit the process, wait for restart
+            process::exit(0);
+        });
+
+    let mut channel = init_channel(&amqp_url);
+
+    // thread send msg to mq
+    let _ = thread::Builder::new()
+        .name("publisher".to_string())
+        .spawn(move || {
+            loop {
+                let ret = rx.recv();
+                if ret.is_err() {
+                    break;
+                }
+                let (routing_key, msg) = ret.unwrap();
+                let ret = channel.basic_publish(
+                    EXCHANGE,
+                    &routing_key,
+                    false,
+                    false,
+                    protocol::basic::BasicProperties {
+                        content_type: Some("text".to_string()),
+                        ..Default::default()
+                    },
+                    msg,
+                );
+                if ret.is_err() {
+                    break;
+                }
+            }
+            let _ = channel.close(200, "Bye");
+            // Rabbitmq connection closed, amqp didn't handle this failure
+            // So we must exit the process, wait for restart
+            process::exit(0);
+        });
+}


### PR DESCRIPTION
Use lapin-futures instead of rust-amqp for pubsub_rabbitmq (api compatibility).