### PR TITLE
make kvdb.close() as public function

### DIFF
--- a/util/src/kvdb.rs
+++ b/util/src/kvdb.rs
@@ -754,7 +754,7 @@ impl Database {
     }
 
     /// Close the database
-    fn close(&self) {
+    pub fn close(&self) {
         *self.db.write() = None;
         self.overlay.write().clear();
         self.flushing.write().clear();


### PR DESCRIPTION
Providing a way to close a DB instance is necessary for outside caller to close/re-open databases gracefully. So I make `close()` as public function.