### PR TITLE
Add an example for cita-web3.

### DIFF
--- a/cita-web3/README.md
+++ b/cita-web3/README.md
@@ -1,0 +1,37 @@
+# CITA-Web3
+
+Rust implementation of JSON-RPC multi-transport client for [CITA].
+
+[CITA]: https://github.com/cryptape/cita
+
+## Usage
+
+First, add the dependencies to `Cargo.toml`:
+
+```toml
+[dependencies]
+cita-web3 = { git = "https://github.com/cryptape/cita-common" }
+
+[features]
+default = ["secp256k1", "sha3hash"]
+secp256k1 = ["cita-web3/secp256k1"]
+ed25519 = ["cita-web3/ed25519"]
+sm2 = ["cita-web3/sm2"]
+sha3hash = ["cita-web3/sha3hash"]
+blake2bhash = ["cita-web3/blake2bhash"]
+sm3hash = ["cita-web3/sm3hash"]
+```
+
+Then, add this crate to the source codes:
+
+```rust
+extern crate cita_web3;
+```
+
+## Examples
+
+- [Query the Block Height](examples/query_height.rs)
+
+  ```sh
+  cargo run --example query_height --features "secp256k1 sha3hash" http://IP:PORT
+  ```

--- a/cita-web3/examples/query_height.rs
+++ b/cita-web3/examples/query_height.rs
@@ -1,0 +1,36 @@
+// CITA
+// Copyright 2016-2018 Cryptape Technologies LLC.
+
+// This program is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any
+// later version.
+
+// This program is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied
+// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+extern crate cita_web3;
+
+use cita_web3::web3::futures::Future;
+
+fn main() {
+    let url = {
+        let mut args = ::std::env::args();
+        args.nth(1).unwrap()
+    };
+    let (_eloop, transport) = cita_web3::web3::transports::Http::new(url.as_str()).unwrap();
+    let web3 = cita_web3::web3::Web3::new(transport);
+    let param = cita_web3::types::request::BlockNumberParams::new();
+    let resp = web3
+        .api::<cita_web3::api::Cita<cita_web3::web3::transports::Http>>()
+        .call(param)
+        .wait()
+        .unwrap();
+    println!("Response = {:?}", resp);
+}


### PR DESCRIPTION
To replace the outdated Rust SDK [rust-web3] in [CITA's README.md].

[CITA's README.md]: https://github.com/cryptape/cita/tree/1cbc6d1#apisdk
[rust-web3]: https://github.com/cryptape/rust-web3/tree/f7d8f5a