### PR TITLE
refactor: remove cita-types, hashable, rlp dependencies from merklehash

### DIFF
--- a/.ci-scripts/loop_crates_to_run
+++ b/.ci-scripts/loop_crates_to_run
@@ -114,7 +114,7 @@ function cargo_run_all () {
 
     cargo_run util
 
-    for crate in hashable merklehash db cita-secp256k1 cita-ed25519 cita-sm2; do
+    for crate in hashable merklehash cita-merklehash db cita-secp256k1 cita-ed25519 cita-sm2; do
         cargo_run ${crate} --features "${SELECT_HASH}"
     done
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cita-merklehash"
+version = "0.1.0"
+dependencies = [
+ "cita-types 0.1.0",
+ "hashable 0.1.0",
+ "merklehash 0.1.0",
+ "rlp 0.2.0",
+ "rlp_derive 0.1.0",
+]
+
+[[package]]
 name = "cita-secp256k1"
 version = "0.6.0"
 dependencies = [
@@ -1166,11 +1177,11 @@ name = "libproto"
 version = "0.6.0"
 dependencies = [
  "cita-crypto 0.1.0",
+ "cita-merklehash 0.1.0",
  "cita-types 0.1.0",
  "grpc 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashable 0.1.0",
  "logger 0.1.0",
- "merklehash 0.1.0",
  "protobuf 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.2.0",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "ethcore-bloom-journal",
     "hashable",
     "merklehash",
+    "cita-merklehash",
     "blake2b",
     "cita-sm2",
     "cita-secp256k1",

--- a/cita-merklehash/Cargo.toml
+++ b/cita-merklehash/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
-name = "merklehash"
+name = "cita-merklehash"
 version = "0.1.0"
 authors = ["Cryptape Technologies <contact@cryptape.com>"]
 
-[dev-dependencies]
+[dependencies]
 cita-types = { path = "../cita-types" }
 hashable = { path = "../hashable" }
 rlp = { path = "../rlp" }
 rlp_derive = { path = "../rlp_derive" }
+merklehash = { path = "../merklehash" }
 
 [features]
 default = []

--- a/cita-merklehash/src/lib.rs
+++ b/cita-merklehash/src/lib.rs
@@ -1,0 +1,62 @@
+// CITA
+// Copyright 2016-2018 Cryptape Technologies LLC.
+
+// This program is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any
+// later version.
+
+// This program is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied
+// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+extern crate cita_types;
+extern crate hashable;
+extern crate rlp;
+#[macro_use]
+extern crate rlp_derive;
+extern crate merklehash;
+
+use self::hashable::Hashable;
+use cita_types::H256;
+use merklehash::{Proof as MerkelProof, ProofNode as MerkelProofNode};
+use rlp::RlpStream;
+
+pub use self::hashable::HASH_NULL_RLP as HASH_NULL;
+pub use merklehash::Tree;
+
+#[derive(Debug, Clone, RlpEncodable, RlpDecodable)]
+pub struct ProofNode {
+    is_right: bool,
+    hash: H256,
+}
+
+#[derive(Debug, Clone, RlpEncodableWrapper, RlpDecodableWrapper)]
+pub struct Proof(Vec<ProofNode>);
+
+pub fn merge(left: &H256, right: &H256) -> H256 {
+    let mut stream = RlpStream::new();
+    stream.append(left);
+    stream.append(right);
+    stream.out().crypt_hash()
+}
+
+impl From<MerkelProofNode<H256>> for ProofNode {
+    fn from(node: MerkelProofNode<H256>) -> Self {
+        ProofNode {
+            is_right: node.is_right,
+            hash: node.hash,
+        }
+    }
+}
+
+impl From<MerkelProof<H256>> for Proof {
+    fn from(proof: MerkelProof<H256>) -> Self {
+        Proof(proof.0.into_iter().map(|n| ProofNode::from(n)).collect())
+    }
+}

--- a/libproto/Cargo.toml
+++ b/libproto/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Cryptape Technologies <contact@cryptape.com>"]
 [dependencies]
 protobuf = { version = "2.0.4", features = ["with-bytes"]}
 cita-types = { path = "../cita-types" }
-merklehash = { path = "../merklehash" }
+cita-merklehash = { path = "../cita-merklehash" }
 cita-crypto = { path = "../cita-crypto" }
 hashable = { path = "../hashable" }
 snappy = { path = "../snappy" }
@@ -25,6 +25,6 @@ default = []
 secp256k1 = ["cita-crypto/secp256k1"]
 ed25519 = ["cita-crypto/ed25519"]
 sm2 = ["cita-crypto/sm2"]
-sha3hash = ["hashable/sha3hash", "merklehash/sha3hash"]
-blake2bhash = ["hashable/blake2bhash", "merklehash/blake2bhash"]
-sm3hash = ["hashable/sm3hash", "merklehash/sm3hash"]
+sha3hash = ["hashable/sha3hash", "cita-merklehash/sha3hash"]
+blake2bhash = ["hashable/blake2bhash", "cita-merklehash/blake2bhash"]
+sm3hash = ["hashable/sm3hash", "cita-merklehash/sm3hash"]

--- a/libproto/src/lib.rs
+++ b/libproto/src/lib.rs
@@ -28,7 +28,7 @@ extern crate rlp;
 extern crate rustc_serialize;
 #[macro_use]
 extern crate serde_derive;
-extern crate merklehash;
+extern crate cita_merklehash;
 extern crate snappy;
 extern crate tls_api;
 
@@ -37,6 +37,7 @@ pub use protos::*;
 mod autoimpl;
 pub mod router;
 
+use cita_merklehash::{merge, Tree, HASH_NULL};
 use crypto::{
     CreateKey, KeyPair, Message as SignMessage, PrivKey, PubKey, Sign, Signature,
     SIGNATURE_BYTES_LEN,
@@ -359,7 +360,7 @@ impl BlockBody {
     }
 
     pub fn transactions_root(&self) -> H256 {
-        merklehash::Tree::from_hashes(self.transaction_hashes().clone()).get_root_hash()
+        *Tree::from_hashes(self.transaction_hashes().clone(), merge, HASH_NULL).get_root_hash()
     }
 
     pub fn from_transactions(stxs: Vec<SignedTransaction>) -> BlockBody {
@@ -389,7 +390,7 @@ impl CompactBlockBody {
     }
 
     pub fn transactions_root(&self) -> H256 {
-        merklehash::Tree::from_hashes(self.transaction_hashes().clone()).get_root_hash()
+        *Tree::from_hashes(self.transaction_hashes().clone(), merge, HASH_NULL).get_root_hash()
     }
 }
 

--- a/merklehash/src/lib.rs
+++ b/merklehash/src/lib.rs
@@ -19,32 +19,30 @@
 //!
 //! This module should be used to generate complete merkle tree root hash.
 
-extern crate cita_types;
-extern crate hashable;
-extern crate rlp;
-#[macro_use]
-extern crate rlp_derive;
-
-use cita_types::H256;
-use hashable::{Hashable, HASH_NULL_RLP};
-use rlp::RlpStream;
+use std::cmp::PartialEq;
+use std::marker::PhantomData;
 
 #[derive(Debug, Clone)]
-pub struct Tree {
-    nodes: Vec<H256>,
+pub struct Tree<T, M> {
+    nodes: Vec<T>,
     input_size: usize,
+    phanton: PhantomData<M>,
 }
 
-#[derive(Debug, Clone, RlpEncodable, RlpDecodable)]
-pub struct ProofNode {
-    is_right: bool,
-    hash: H256,
+#[derive(Debug, Clone)]
+pub struct ProofNode<T> {
+    pub is_right: bool,
+    pub hash: T,
 }
 
-#[derive(Debug, Clone, RlpEncodableWrapper, RlpDecodableWrapper)]
-pub struct Proof(Vec<ProofNode>);
+#[derive(Debug, Clone)]
+pub struct Proof<T>(pub Vec<ProofNode<T>>);
 
-impl Tree {
+impl<T, M> Tree<T, M>
+where
+    T: Default + Clone + PartialEq,
+    M: Fn(&T, &T) -> T,
+{
     // For example, there is 11 hashes [A..K] are used to generate a merkle tree:
     //
     //      A_B C_D E_F
@@ -66,19 +64,19 @@ impl Tree {
     //      5. Update for 3..6: [_, _, _, 3, 4, 5, 6, 7, 8, 9, G, H, I, J, K, A, B, C, D, E, F]
     //      6. Update for 1..2: [_, 1, 2, 3, 4, 5, 6, 7, 8, 9, G, H, I, J, K, A, B, C, D, E, F]
     //      7. Update for 0:    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, G, H, I, J, K, A, B, C, D, E, F]
-    pub fn from_hashes(input: Vec<H256>) -> Self {
+    pub fn from_hashes(input: Vec<T>, merge: M, null: T) -> Self {
         let input_size = input.len();
 
         let nodes = match input_size {
             // in case of empty slice, just return HASH_NULL_RLP
-            0 => vec![HASH_NULL_RLP],
+            0 => vec![null],
 
             // If only one input.
             1 => input,
 
             _ => {
                 let nodes_size = get_size_of_nodes(input_size);
-                let mut nodes = vec![H256::default(); nodes_size];
+                let mut nodes = vec![T::default(); nodes_size];
 
                 let rows_size = get_size_of_rows(input_size);
                 let lowest_row_index = rows_size - 1;
@@ -89,25 +87,30 @@ impl Tree {
 
                 // Insert the input into the merkle tree.
                 for i in 0..nodes_size_of_lowest_row {
-                    nodes[first_index_in_lowest_row + i] = input[i]
+                    nodes[first_index_in_lowest_row + i] = input[i].clone()
                 }
                 for i in 0..input_size - nodes_size_of_lowest_row {
-                    nodes[first_input_node_index + i] = input[nodes_size_of_lowest_row + i];
+                    nodes[first_input_node_index + i] = input[nodes_size_of_lowest_row + i].clone();
                 }
 
                 let max_nodes_size_of_lowest_row = 1 << lowest_row_index;
                 // Calc hash for the lowest row
                 if max_nodes_size_of_lowest_row == input_size {
                     // The lowest row is full.
-                    calc_tree_at_row(&mut nodes, lowest_row_index, 0)
+                    calc_tree_at_row(&mut nodes, lowest_row_index, 0, &merge)
                 } else {
-                    calc_tree_at_row(&mut nodes, lowest_row_index, nodes_size_of_lowest_row >> 1);
+                    calc_tree_at_row(
+                        &mut nodes,
+                        lowest_row_index,
+                        nodes_size_of_lowest_row >> 1,
+                        &merge,
+                    );
                 }
 
                 // From the second row from the bottom to the second row from the top.
                 for i in 1..lowest_row_index {
                     let row_index = lowest_row_index - i;
-                    calc_tree_at_row(&mut nodes, row_index, 0);
+                    calc_tree_at_row(&mut nodes, row_index, 0, &merge);
                 }
 
                 nodes
@@ -115,30 +118,24 @@ impl Tree {
         };
 
         Self {
-            nodes: nodes,
-            input_size: input_size,
+            nodes,
+            input_size,
+            phanton: PhantomData,
         }
     }
 
-    pub fn from_bytes<I>(input: I) -> Self
-    where
-        I: IntoIterator<Item = Vec<u8>>,
-    {
-        Self::from_hashes(input.into_iter().map(|v| v.crypt_hash()).collect())
+    pub fn get_root_hash(&self) -> &T {
+        &self.nodes[0]
     }
 
-    pub fn get_root_hash(&self) -> H256 {
-        self.nodes[0]
-    }
-
-    pub fn get_proof_by_input_index(&self, input_index: usize) -> Option<Proof> {
+    pub fn get_proof_by_input_index(&self, input_index: usize) -> Option<Proof<T>> {
         get_proof_indexes(input_index, self.input_size).map(|indexes| {
-            Proof(
+            Proof::<T>(
                 indexes
                     .into_iter()
-                    .map(|i| ProofNode {
+                    .map(|i| ProofNode::<T> {
                         is_right: (i & 1) == 0,
-                        hash: self.nodes[i],
+                        hash: self.nodes[i].clone(),
                     })
                     .collect(),
             )
@@ -146,21 +143,30 @@ impl Tree {
     }
 }
 
-impl Proof {
-    pub fn verify(&self, root_hash: H256, data_hash: H256) -> bool {
-        self.0.iter().fold(data_hash, |h, ref x| {
+impl<T> Proof<T>
+where
+    T: Default + Clone + PartialEq,
+{
+    pub fn verify<M>(&self, root: T, data: T, merge: M) -> bool
+    where
+        M: Fn(&T, &T) -> T,
+    {
+        self.0.iter().fold(data, |h, ref x| {
             if x.is_right {
                 merge(&h, &x.hash)
             } else {
                 merge(&x.hash, &h)
             }
-        }) == root_hash
+        }) == root
     }
 }
 
 // Calc hash for one row in merkle tree.
 // If break_cnt > 0, just calc break_cnt hash for that row.
-fn calc_tree_at_row(nodes: &mut Vec<H256>, row_index: usize, break_cnt: usize) {
+fn calc_tree_at_row<T, M>(nodes: &mut Vec<T>, row_index: usize, break_cnt: usize, merge: M)
+where
+    M: Fn(&T, &T) -> T,
+{
     // The first index in the row which above the row_index row.
     let index_update = (1 << (row_index - 1)) - 1;
     let size_max = 1 << (row_index - 1);
@@ -173,13 +179,6 @@ fn calc_tree_at_row(nodes: &mut Vec<H256>, row_index: usize, break_cnt: usize) {
         let j = index_update + i;
         nodes[j] = merge(&nodes[j * 2 + 1], &nodes[j * 2 + 2]);
     }
-}
-
-fn merge(left: &H256, right: &H256) -> H256 {
-    let mut stream = RlpStream::new();
-    stream.append(left);
-    stream.append(right);
-    stream.out().crypt_hash()
 }
 
 #[inline]
@@ -257,10 +256,20 @@ fn get_proof_indexes(input_index: usize, input_size: usize) -> Option<Vec<usize>
 
 #[cfg(test)]
 mod tests {
-    use super::Proof;
-    use hashable::{Hashable, HASH_NULL_RLP};
-    use rlp;
-    use rlp::Encodable;
+    extern crate cita_types;
+    extern crate hashable;
+    extern crate rlp;
+
+    use self::cita_types::H256;
+    use self::hashable::{Hashable, HASH_NULL_RLP};
+    use self::rlp::RlpStream;
+
+    fn merge(left: &H256, right: &H256) -> H256 {
+        let mut stream = RlpStream::new();
+        stream.append(left);
+        stream.append(right);
+        stream.out().crypt_hash()
+    }
 
     #[test]
     fn test_size_of_rows() {
@@ -373,7 +382,11 @@ mod tests {
             ],
         ];
         for input in inputs {
-            let tree = super::Tree::from_bytes(input.clone());
+            let tree = super::Tree::from_hashes(
+                input.clone().into_iter().map(|v| v.crypt_hash()).collect(),
+                merge,
+                HASH_NULL_RLP,
+            );
             let root_hash = tree.get_root_hash();
             let input_size = input.len();
             let loop_size = if input_size == 0 { 1 } else { input_size };
@@ -386,124 +399,130 @@ mod tests {
                 let proof = tree
                     .get_proof_by_input_index(index)
                     .expect("proof is not none");
-                assert!(proof.verify(root_hash, data_hash));
-                // encode and decode
-                let proof_bytes = proof.rlp_bytes().to_vec();
-                let proof_decode: Proof = rlp::decode(&proof_bytes);
-                assert!(proof_decode.verify(root_hash, data_hash));
+                assert!(proof.verify(*root_hash, data_hash, merge));
             }
         }
     }
-}
 
-#[cfg(test)]
-#[cfg(feature = "sha3hash")]
-mod tests_for_sha3hash {
-    use super::Tree;
-    use cita_types::H256;
-    use std::str::FromStr;
+    #[cfg(feature = "sha3hash")]
+    mod tests_for_sha3hash {
+        use super::super::Tree;
+        use super::cita_types::H256;
+        use super::hashable::{Hashable, HASH_NULL_RLP};
+        use super::merge;
+        use std::str::FromStr;
 
-    #[test]
-    fn test_from_bytes() {
-        let check = vec![
-            (
-                vec![],
-                "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
-            ),
-            (
-                vec![b"".to_vec()],
-                "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-            ),
-            (
-                vec![b"A".to_vec()],
-                "03783fac2efed8fbc9ad443e592ee30e61d65f471140c10ca155e937b435b760",
-            ),
-            (
-                vec![
-                    b"A".to_vec(),
-                    b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_vec(),
-                ],
-                "9bd41e0d43f4ec7a703edc2eb9fbb4106e1bc2a845e9ee1d4f3f4cf99b8549e6",
-            ),
-            (
-                vec![
-                    b"A".to_vec(),
-                    b"aaaa".to_vec(),
-                    b"abaa".to_vec(),
-                    b"aaba".to_vec(),
-                    b"aaab".to_vec(),
-                ],
-                "8e827ab731f2416f6057b9c7f241b1841e345ffeabb4274e35995a45f4d42a1a",
-            ),
-            (
-                vec![
-                    b"a".to_vec(),
-                    b"b".to_vec(),
-                    b"c".to_vec(),
-                    b"d".to_vec(),
-                    b"e".to_vec(),
-                    b"f".to_vec(),
-                    b"g".to_vec(),
-                ],
-                "768dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1",
-            ),
-        ];
-        for (x, y) in check {
-            assert_eq!(
-                Tree::from_bytes(x).get_root_hash(),
-                H256::from_str(y).unwrap()
-            );
-        }
-    }
-
-    #[test]
-    fn test_from_hashes() {
-        let check = vec![
-            (
-                vec![
+        #[test]
+        fn test_from_bytes() {
+            let check = vec![
+                (
+                    vec![],
+                    "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                ),
+                (
+                    vec![b"".to_vec()],
+                    "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+                ),
+                (
+                    vec![b"A".to_vec()],
+                    "03783fac2efed8fbc9ad443e592ee30e61d65f471140c10ca155e937b435b760",
+                ),
+                (
+                    vec![
+                        b"A".to_vec(),
+                        b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_vec(),
+                    ],
+                    "9bd41e0d43f4ec7a703edc2eb9fbb4106e1bc2a845e9ee1d4f3f4cf99b8549e6",
+                ),
+                (
+                    vec![
+                        b"A".to_vec(),
+                        b"aaaa".to_vec(),
+                        b"abaa".to_vec(),
+                        b"aaba".to_vec(),
+                        b"aaab".to_vec(),
+                    ],
                     "8e827ab731f2416f6057b9c7f241b1841e345ffeabb4274e35995a45f4d42a1a",
+                ),
+                (
+                    vec![
+                        b"a".to_vec(),
+                        b"b".to_vec(),
+                        b"c".to_vec(),
+                        b"d".to_vec(),
+                        b"e".to_vec(),
+                        b"f".to_vec(),
+                        b"g".to_vec(),
+                    ],
                     "768dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1",
-                ],
-                "42d89ed38fbef98df15d80913bd54e5964dee662e41936b9e061e3cb3211a6be",
-            ),
-            (
-                vec![
-                    "42d89ed38fbef98df15d80913bd54e5964dee662e41936b9e061e3cb3211a6be",
-                    "e68dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1",
-                ],
-                "e73b5eff121d65174af0517361b1ecc01efeb869f9f79c27dd02f5d0dec42d11",
-            ),
-            (
-                vec![
-                    "f68dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1",
-                    "968dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1",
-                ],
-                "9c436eab724269a0e75d2d2feeda33b7c0e5febec118f9bdf52383ada0911cf3",
-            ),
-            (
-                vec![
-                    "e73b5eff121d65174af0517361b1ecc01efeb869f9f79c27dd02f5d0dec42d11",
-                    "9c436eab724269a0e75d2d2feeda33b7c0e5febec118f9bdf52383ada0911cf3",
-                ],
-                "e30a149e738cfaf89fb3a2267d7109a1bda978320426c2ff8b3a2d77aa103a6a",
-            ),
-            (
-                vec![
-                    "8e827ab731f2416f6057b9c7f241b1841e345ffeabb4274e35995a45f4d42a1a",
-                    "768dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1",
-                    "e68dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1",
-                    "f68dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1",
-                    "968dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1",
-                ],
-                "e30a149e738cfaf89fb3a2267d7109a1bda978320426c2ff8b3a2d77aa103a6a",
-            ),
-        ];
-        for (x, y) in check {
-            assert_eq!(
-                Tree::from_hashes(x.into_iter().map(|x| H256::from_str(x).unwrap()).collect())
+                ),
+            ];
+            for (x, y) in check {
+                assert_eq!(
+                    Tree::from_hashes(
+                        x.into_iter().map(|v| v.crypt_hash()).collect(),
+                        merge,
+                        HASH_NULL_RLP
+                    )
                     .get_root_hash(),
-                H256::from_str(y).unwrap()
-            );
+                    &H256::from_str(y).unwrap()
+                );
+            }
+        }
+
+        #[test]
+        fn test_from_hashes() {
+            let check = vec![
+                (
+                    vec![
+                        "8e827ab731f2416f6057b9c7f241b1841e345ffeabb4274e35995a45f4d42a1a",
+                        "768dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1",
+                    ],
+                    "42d89ed38fbef98df15d80913bd54e5964dee662e41936b9e061e3cb3211a6be",
+                ),
+                (
+                    vec![
+                        "42d89ed38fbef98df15d80913bd54e5964dee662e41936b9e061e3cb3211a6be",
+                        "e68dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1",
+                    ],
+                    "e73b5eff121d65174af0517361b1ecc01efeb869f9f79c27dd02f5d0dec42d11",
+                ),
+                (
+                    vec![
+                        "f68dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1",
+                        "968dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1",
+                    ],
+                    "9c436eab724269a0e75d2d2feeda33b7c0e5febec118f9bdf52383ada0911cf3",
+                ),
+                (
+                    vec![
+                        "e73b5eff121d65174af0517361b1ecc01efeb869f9f79c27dd02f5d0dec42d11",
+                        "9c436eab724269a0e75d2d2feeda33b7c0e5febec118f9bdf52383ada0911cf3",
+                    ],
+                    "e30a149e738cfaf89fb3a2267d7109a1bda978320426c2ff8b3a2d77aa103a6a",
+                ),
+                (
+                    vec![
+                        "8e827ab731f2416f6057b9c7f241b1841e345ffeabb4274e35995a45f4d42a1a",
+                        "768dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1",
+                        "e68dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1",
+                        "f68dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1",
+                        "968dfb4ca3311fa3bf4d696dde334e30edf3542e8ea114a4f9d18fb34365f1d1",
+                    ],
+                    "e30a149e738cfaf89fb3a2267d7109a1bda978320426c2ff8b3a2d77aa103a6a",
+                ),
+            ];
+            for (x, y) in check {
+                assert_eq!(
+                    Tree::from_hashes(
+                        x.into_iter().map(|x| H256::from_str(x).unwrap()).collect(),
+                        merge,
+                        HASH_NULL_RLP
+                    )
+                    .get_root_hash(),
+                    &H256::from_str(y).unwrap()
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
1. remove `cita-types`, `hashable`, `rlp` dependencies from merklehash
2. add another crate cita-merklehash associated with the `cita-types`, `cita-hash`, `cita-serde` and `cita-merge`.

TODO: 
1. Add a TreeBuilder in cita-merklehash
2. Rename merklehash to static-merkle
3. fix the test, merkelhash should build without any features.


https://github.com/cryptape/cita-common/issues/170