### PR TITLE
chore: pub use Itertools in db

### DIFF
--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -23,6 +23,7 @@ pub mod trie;
 pub mod triehash;
 
 pub use hashdb::*;
+pub use itertools::Itertools;
 pub use journaldb::JournalDB;
 pub use kvdb::*;
 pub use memorydb::MemoryDB;


### PR DESCRIPTION
https://github.com/cryptape/cita/blob/066e8b59f975fc5c1e481b81911869093b8ddc5e/cita-executor/src/backlogs.rs#L22

We should pub use Itertools, otherwise the `earlymergedb` could not be imported correctly.

https://github.com/cryptape/cita-common/blob/950eeb1c6afd9b08f35bfb9050919713454b31f8/db/src/journaldb/earlymergedb.rs#L27
