### PR TITLE
Use stable rust toolchain as default (part 2)

### DIFF
--- a/jsonrpc-types/src/lib.rs
+++ b/jsonrpc-types/src/lib.rs
@@ -15,10 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#![feature(try_from)]
-#![feature(concat_idents)]
-#![allow(unused_attributes)]
-#![allow(unused_extern_crates)]
 extern crate bincode;
 extern crate cita_types;
 extern crate libproto;

--- a/jsonrpc-types/src/request/proto.rs
+++ b/jsonrpc-types/src/request/proto.rs
@@ -15,11 +15,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use libproto::{TryFrom, TryInto};
 /// Convert JSON-RPC request to proto request.
 use rustc_serialize::hex::FromHex;
 use serde_json;
-use std::convert::TryFrom;
-use std::convert::{Into, TryInto};
+use std::convert::Into;
 use uuid::Uuid;
 
 use cita_types::clean_0x;

--- a/jsonrpc-types/src/request/request.rs
+++ b/jsonrpc-types/src/request/request.rs
@@ -15,9 +15,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use libproto::TryInto;
 /// JSON-RPC Request.
 use serde_json;
-use std::convert::TryInto;
 
 use internals::construct_params;
 use libproto::request::Request as ProtoRequest;

--- a/jsonrpc-types/src/rpctypes/basic/fixed_data.rs
+++ b/jsonrpc-types/src/rpctypes/basic/fixed_data.rs
@@ -35,7 +35,7 @@ struct Data32Visitor;
 struct Data20Visitor;
 
 macro_rules! impl_for_fixed_type {
-    ($outer:ident, $inner:ident, $outer_size:expr) => {
+    ($outer:ident, $inner:ident, $outer_size:expr, $visitor:ident) => {
         impl $outer {
             pub fn new(data: $inner) -> $outer {
                 $outer(data)
@@ -56,11 +56,11 @@ macro_rules! impl_for_fixed_type {
             where
                 D: Deserializer<'de>,
             {
-                deserializer.deserialize_str(concat_idents!($outer, Visitor))
+                deserializer.deserialize_str($visitor)
             }
         }
 
-        impl<'de> Visitor<'de> for concat_idents!($outer, Visitor) {
+        impl<'de> Visitor<'de> for $visitor {
             type Value = $outer;
 
             fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
@@ -129,8 +129,8 @@ macro_rules! impl_for_fixed_type {
     };
 }
 
-impl_for_fixed_type!(Data32, H256, 32usize);
-impl_for_fixed_type!(Data20, H160, 20usize);
+impl_for_fixed_type!(Data32, H256, 32usize, Data32Visitor);
+impl_for_fixed_type!(Data20, H160, 20usize, Data20Visitor);
 
 macro_rules! test_for_fixed_type {
     ($test_name:ident, $outer:ident, $inner:ident, $outer_size:expr) => {

--- a/jsonrpc-types/src/rpctypes/block.rs
+++ b/jsonrpc-types/src/rpctypes/block.rs
@@ -19,8 +19,8 @@ use super::Proof;
 use super::RpcBlock;
 use super::{BlockTransaction, FullTransaction};
 use cita_types::{Address, H256, U256};
+use libproto::TryFrom;
 use libproto::{Block as ProtoBlock, BlockHeader as ProtoBlockHeader};
-use std::convert::TryFrom;
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct BlockBody {

--- a/jsonrpc-types/src/rpctypes/transaction.rs
+++ b/jsonrpc-types/src/rpctypes/transaction.rs
@@ -17,11 +17,11 @@
 
 use cita_types::traits::LowerHex;
 use cita_types::{Address, H256, U256};
+use libproto::TryInto;
 use libproto::{
     FullTransaction as ProtoFullTransaction, SignedTransaction as ProtoSignedTransaction,
 };
 use rpctypes::Data;
-use std::convert::TryInto;
 
 // TODO: No need Deserialize. Just because test in trans.rs
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]

--- a/libproto/src/autoimpl.rs
+++ b/libproto/src/autoimpl.rs
@@ -19,14 +19,14 @@ use protobuf::{parse_from_bytes, Message as MessageTrait};
 pub use protos::InnerMessage_oneof_content as MsgClass;
 use protos::*;
 use snappy;
-use std::convert::{From, Into, TryFrom, TryInto};
+use std::convert::{From, Into};
 
 pub use std::u32::MAX as ZERO_ORIGIN;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct TryFromConvertError(());
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct TryIntoConvertError(());
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -37,6 +37,19 @@ pub enum OperateType {
 }
 
 pub const DEFAULT_OPERATE_TYPE: OperateType = OperateType::Broadcast;
+
+pub trait TryFrom<T>
+where
+    Self: ::std::marker::Sized,
+{
+    type Error;
+    fn try_from(value: T) -> Result<Self, Self::Error>;
+}
+
+pub trait TryInto<T> {
+    type Error;
+    fn try_into(self) -> Result<T, Self::Error>;
+}
 
 impl TryFrom<u8> for OperateType {
     type Error = TryFromConvertError;
@@ -594,7 +607,7 @@ mod tests {
     #[test]
     fn convert_operate_type_works() {
         use super::OperateType;
-        use std::convert::TryFrom;
+        use super::TryFrom;
         let ot1 = OperateType::Broadcast;
         assert_eq!(ot1, OperateType::Broadcast);
         assert_eq!(ot1 as u8, OperateType::Broadcast as u8);
@@ -633,7 +646,7 @@ mod tests {
     #[test]
     fn traits_for_all_protos_works() {
         use super::blockchain;
-        use std::convert::{TryFrom, TryInto};
+        use super::{TryFrom, TryInto};
         let height: u64 = 13579;
         let mut status = blockchain::Status::new();
         status.set_height(height);
@@ -668,7 +681,8 @@ mod tests {
     #[test]
     fn class_funcs_for_message_works() {
         use super::{Message, MsgClass, OperateType, Request, Response};
-        use std::convert::{Into, TryFrom, TryInto};
+        use super::{TryFrom, TryInto};
+        use std::convert::Into;
 
         let req_origin = Request::new();
         let resp_origin = Response::new();

--- a/libproto/src/lib.rs
+++ b/libproto/src/lib.rs
@@ -15,8 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#![feature(try_from)]
-
 extern crate cita_crypto as crypto;
 extern crate cita_types as types;
 extern crate grpc;
@@ -46,15 +44,15 @@ use hashable::Hashable;
 use protobuf::RepeatedField;
 use rlp::{Decodable, DecoderError, Encodable, RlpStream, UntrustedRlp};
 use rustc_serialize::hex::ToHex;
-use std::convert::{From, TryFrom, TryInto};
+use std::convert::From;
 use std::ops::Deref;
-use std::result::Result::Err;
 use types::{Address, H256};
 
 pub use autoimpl::{
     Message, MsgClass, OperateType, Origin, RawBytes, TryFromConvertError, TryIntoConvertError,
     ZERO_ORIGIN,
 };
+pub use autoimpl::{TryFrom, TryInto};
 
 //TODO respone contain error
 #[derive(Serialize, Deserialize, Debug, PartialEq)]


### PR DESCRIPTION
- Remove unstable features: `concat_idents` and `try_from`.