### PR TITLE
Close KeyValueDB

### DIFF
--- a/db/src/kvdb/mod.rs
+++ b/db/src/kvdb/mod.rs
@@ -166,4 +166,7 @@ pub trait KeyValueDB: Sync + Send {
 
     /// Attempt to replace this database with a new one located at the given path.
     fn restore(&self, new_db: &str) -> Result<(), UtilError>;
+
+    /// Close database handler
+    fn close(&self) {}
 }

--- a/db/src/kvdb/rocksdb.rs
+++ b/db/src/kvdb/rocksdb.rs
@@ -730,6 +730,10 @@ impl KeyValueDB for Database {
     fn restore(&self, new_db: &str) -> Result<(), UtilError> {
         Database::restore(self, new_db)
     }
+
+    fn close(&self) {
+        Database::close(self)
+    }
 }
 
 impl Drop for Database {


### PR DESCRIPTION
Add `close` interface into trait `KeyValueDB`, so that able to close RocksDB outside.

scenario which requires to close RocksDB, is that cita-executor would like to close snapshot-database after restoring, to ensure db-handler has been released correctly.