### PR TITLE
Revert "Add bors file. [skip ci]"

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,0 @@
-status = ["ci/circleci"]
-# Uncomment this to use a two hour timeout.
-# The default is one hour.
-# timeout_sec = 7200
-required_approvals = 2
-delete_merged_branches = true


### PR DESCRIPTION
This reverts commit 2abf5170c7a9d46ac43731d56fae24efc57f5301.

Not sure if it affects the ci. and bors will be tested first. 