### PR TITLE
run clippy for web3

### DIFF
--- a/.ci-scripts/loop_crates_to_run
+++ b/.ci-scripts/loop_crates_to_run
@@ -182,7 +182,7 @@ function cargo_run_all_for_clippy () {
     cargo_run util
 
     cargo_run jsonrpc-types
-    cargo_run_skip cita-web3
+    cargo_run cita-web3
 
     cargo_run cita-secp256k1 --features "${SELECT_HASH}"
     cargo_run cita-ed25519 --features "${SELECT_HASH}"


### PR DESCRIPTION
cita-web3/Cargo.toml:

```
[dependencies]
jsonrpc-types = { path = "../jsonrpc-types" }
web3 = "0.4.0"
```

So, #239  should be merged firstly.