### PR TITLE
New log pattern.

### DIFF
--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -209,7 +209,9 @@ fn create_loggers(directives: Vec<Directive>, appender: &str) -> Vec<Logger> {
 // FileAppender config
 fn config_file_appender(file_path: &str, directives: Vec<Directive>) -> Config {
     let requests = FileAppender::builder()
-        .encoder(Box::new(PatternEncoder::new("{d} - {l} - {m}{n}")))
+        .encoder(Box::new(PatternEncoder::new(
+            "{d(%Y-%m-%d - %H:%M:%S)} | {t:20.20} - {L:5} | {l:5} - {m}{n}",
+        )))
         .build(file_path)
         .unwrap();
 


### PR DESCRIPTION
* Remove the `thread name`. only show `main` and `unnamed`, no need
* Limit the path to the 20 byte.
* preview
auth:
![Screenshot from 2019-05-06 10-59-08](https://user-images.githubusercontent.com/8768261/57205011-09461c00-6fee-11e9-9c88-7ccbab5bc92c.png)
bft:
![Screenshot from 2019-05-06 10-59-55](https://user-images.githubusercontent.com/8768261/57205026-1ebb4600-6fee-11e9-84b3-97a438b3b375.png)
chain:
![Screenshot from 2019-05-06 11-00-39](https://user-images.githubusercontent.com/8768261/57205038-37c3f700-6fee-11e9-8882-78c8afb1b178.png)
executor:
![Screenshot from 2019-05-06 11-01-11](https://user-images.githubusercontent.com/8768261/57205054-4ad6c700-6fee-11e9-9b5e-0bddea1f2c85.png)
forever:
![Screenshot from 2019-05-06 11-01-38](https://user-images.githubusercontent.com/8768261/57205062-5d510080-6fee-11e9-8da9-3b7f5090beec.png)
jsonrpc:
![Screenshot from 2019-05-06 11-02-08](https://user-images.githubusercontent.com/8768261/57205071-6cd04980-6fee-11e9-8b7c-d43fbb90cfe0.png)
network:
![Screenshot from 2019-05-06 11-02-40](https://user-images.githubusercontent.com/8768261/57205085-7f4a8300-6fee-11e9-93ca-5a5df5f533eb.png)

https://github.com/cryptape/cita/issues/511