### PR TITLE
Rewrite semantic version.

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -29,13 +29,13 @@ use crate::channel::Sender;
 use crate::types::H256;
 use libproto::blockchain::{Block, RichStatus};
 use std::time::Duration;
-use util::SemanticVersion;
+use util::SemVer;
 
 pub trait Engine: Sync + Send {
     fn name(&self) -> &str;
 
-    fn version(&self) -> SemanticVersion {
-        SemanticVersion::new(1, 2, 3)
+    fn version(&self) -> SemVer {
+        SemVer::new(1, 2, 3)
     }
 
     fn duration(&self) -> Duration;

--- a/util/src/semantic_version.rs
+++ b/util/src/semantic_version.rs
@@ -1,51 +1,28 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
-// This file is part of Parity.
-
-// This software is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-
-// This software is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
-
-//! Semantic version formatting and comparing.
-
-/// A version value with strict meaning. Use `as_u32` to convert to a simple integer.
-///
-/// # Example
-/// ```
-/// extern crate util;
-/// use util::semantic_version::*;
-///
-/// fn main() {
-///   assert_eq!(SemanticVersion::new(1, 2, 3).as_u32(), 0x010203);
-/// }
-/// ```
-pub struct SemanticVersion {
-    /// Major version - API/feature removals & breaking changes.
+/// Semantic Versioning Specification (SemVer)
+/// Check the detail about it: https://semver.org/spec/v2.0.0.html
+pub struct SemVer {
     pub major: u8,
-    /// Minor version - API/feature additions.
     pub minor: u8,
-    /// Tiny version - bug fixes.
-    pub tiny: u8,
+    pub patch: u8,
 }
 
-impl SemanticVersion {
-    /// Create a new object.
-    pub fn new(major: u8, minor: u8, tiny: u8) -> SemanticVersion {
-        SemanticVersion { major, minor, tiny }
-    }
-
-    /// Convert to a `u32` representation.
-    pub fn as_u32(&self) -> u32 {
-        (u32::from(self.major) << 16) + (u32::from(self.minor) << 8) + u32::from(self.tiny)
+impl SemVer {
+    pub fn new(major: u8, minor: u8, patch: u8) -> Self {
+        SemVer {
+            major,
+            minor,
+            patch,
+        }
     }
 }
 
-// TODO: implement Eq, Comparison and Debug/Display for SemanticVersion.
+impl Default for SemVer {
+    /// Default: `v0.1.0`
+    fn default() -> Self {
+        SemVer {
+            major: 0,
+            minor: 1,
+            patch: 0,
+        }
+    }
+}


### PR DESCRIPTION
It's used by `util/engine`.
