### PR TITLE
fix "Failed to get cita-web3"

### DIFF
--- a/cita-web3/README.md
+++ b/cita-web3/README.md
@@ -11,6 +11,7 @@ First, add the dependencies to `Cargo.toml`:
 ```toml
 [dependencies]
 cita-web3 = { git = "https://github.com/citahub/cita-common" }
+cita-web3 = { git = "https://github.com/citahub/cita-common", branch="develop"}
 ```
 
 Then, add this crate to the source codes:


### PR DESCRIPTION
add the dependencies to `Cargo.toml`, should use `branch="develop"`